### PR TITLE
create useStateRef hook internally

### DIFF
--- a/idom/client/app/package-lock.json
+++ b/idom/client/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "idom-client-react",
-  "version": "0.2.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/idom/client/app/package.json
+++ b/idom/client/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "idom-client-react",
   "description": "A client for IDOM implemented in React",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": "Ryan Morshead",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
this avoids the need to constantly save the update hook
since the original effect function holds onto a ref that
will always be up to date. in the prior implementation
there was some delay that was introduced (presumably due
to triggering updates on stale callbacks).