### PR TITLE
publish docs on push to main

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,35 +1,17 @@
 # This workflows will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
-name: Release
+name: Deploy Documentation
 
 on:
-  release:
-    types:
-      - created
+  push:
+    branches:
+      - "main"
+    tags:
+      - "*"
 
 jobs:
-  publish-package:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: "3.x"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python setup.py bdist_wheel
-          twine upload dist/*
   deploy-documentation:
-    needs: [publish-package]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release-pkg.yml
+++ b/.github/workflows/release-pkg.yml
@@ -1,0 +1,30 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Release Package
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  release-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py bdist_wheel
+          twine upload dist/*

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,7 +8,7 @@
 
 import sys
 from pathlib import Path
-from setuptools_scm import version_from_scm
+from pkg_resources import get_distribution
 
 # -- Path Setup --------------------------------------------------------------
 
@@ -27,12 +27,9 @@ project = "IDOM"
 copyright = "2019, Ryan Morshead"
 author = "Ryan Morshead"
 
-import idom  # noqa
-
-print(str(here.parent))
-_scm_version = version_from_scm(str(here.parent.parent))
-release = _scm_version.tag.base_version
-version = release.rsplit(".", 1)[0]
+release = get_distribution("idom").version
+# for example take major/minor
+version = ".".join(release.split(".")[:2])
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
This means the docs will be up to date with `main` without having to create a release