### PR TITLE
fix displayed version in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,17 @@ project = "IDOM"
 copyright = "2019, Ryan Morshead"
 author = "Ryan Morshead"
 
+dist = get_distribution("idom")
 release = get_distribution("idom").version.split("+")[0]
+
+# Hack because setuptools_scm doesn't play nice with github actions
+# dev0 indicates we're zero distance away from the last release
+# but setuptools_scm still seems to think we're developing. This
+# we need to remedy this misunderstanding.
+if release.endswith(".dev0"):
+    major, minor, patch, *_ = release.split(".")
+    release = f"{major}.{minor}.{int(patch) - 1}"
+
 # for example take major/minor
 version = ".".join(release.split(".")[:2])
 


### PR DESCRIPTION
for some reason setuptools_scm doesn't play nice with
github actions. as a result we need to remove a trailing
dev0 (i.e. zero distance from last release) annotation
that can show up in the release string when deploying
the docs