### PR TITLE
avoid sanic import

### DIFF
--- a/idom/server/__init__.py
+++ b/idom/server/__init__.py
@@ -1,6 +1,6 @@
 from .base import AbstractRenderServer
 from .prefab import run, multiview_server, hotswap_server
-from . import default
+
 
 __all__ = [
     "default",

--- a/idom/server/default.py
+++ b/idom/server/default.py
@@ -1,4 +1,0 @@
-from .sanic import Config, PerClientStateServer, SharedClientStateServer
-
-
-__all__ = ["Config", "PerClientStateServer", "SharedClientStateServer"]

--- a/idom/server/prefab.py
+++ b/idom/server/prefab.py
@@ -1,32 +1,18 @@
-from importlib import import_module
-from typing import Any, Dict, Optional, Tuple, Type, TypeVar, cast
+from typing import Any, Dict, Optional, Tuple, Type, TypeVar
 
 from idom.core.element import ElementConstructor
 from idom.widgets.utils import multiview, hotswap, MultiViewMount, MountFunc
 
 from .base import AbstractRenderServer
-from .utils import find_available_port
+from .utils import find_available_port, find_builtin_server_type
 
 
 _S = TypeVar("_S", bound=AbstractRenderServer[Any, Any])
 
 
-def _find_default_server_type() -> Optional[Type[_S]]:
-    for name in ["sanic.PerClientStateServer"]:
-        module_name, server_name = name.split(".")
-        try:
-            module = import_module(f"idom.server.{module_name}")
-        except ImportError:  # pragma: no cover
-            pass
-        else:
-            return cast(Type[_S], getattr(module, server_name))
-    else:  # pragma: no cover
-        return None
-
-
 def run(
     element: ElementConstructor,
-    server_type: Optional[Type[_S]] = _find_default_server_type(),
+    server_type: Optional[Type[_S]] = find_builtin_server_type("PerClientStateServer"),
     host: str = "127.0.0.1",
     port: Optional[int] = None,
     server_config: Optional[Any] = None,

--- a/idom/server/utils.py
+++ b/idom/server/utils.py
@@ -1,5 +1,37 @@
 from socket import socket
-from typing import cast
+from types import ModuleType
+from typing import Type, Any, List, cast
+from importlib import import_module
+
+
+def find_builtin_server_type(type_name: str) -> Type[Any]:
+    """Find first installed server implementation"""
+    builtin_module_names = ["sanic", "flask", "tornado"]
+
+    installed_builtin_modules: List[ModuleType] = []
+    for module_name in builtin_module_names:
+        try:
+            installed_builtin_modules.append(
+                import_module(f"idom.server.{module_name}")
+            )
+        except ImportError:  # pragma: no cover
+            pass
+
+    if not installed_builtin_modules:  # pragma: no cover
+        raise RuntimeError(
+            f"Found none of the following builtin server implementations {builtin_module_names}"
+        )
+
+    for builtin_module in installed_builtin_modules:
+        try:
+            return getattr(builtin_module, type_name)
+        except AttributeError:  # pragma: no cover
+            pass
+    else:  # pragma: no cover
+        installed_names = [m.__name__ for m in installed_builtin_modules]
+        raise ImportError(
+            f"No server type {type_name!r} found in installed implementations {installed_names}"
+        )
 
 
 def find_available_port(host: str) -> int:

--- a/idom/testing.py
+++ b/idom/testing.py
@@ -16,7 +16,7 @@ from weakref import finalize
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver import Chrome
 
-from idom import server
+from idom.server.utils import find_builtin_server_type
 from idom.server.base import AbstractRenderServer
 from idom.server.prefab import hotswap_server
 from idom.server.utils import find_available_port
@@ -59,7 +59,7 @@ class ServerMountPoint(Generic[_Mount, _Server]):
 
     def __init__(
         self,
-        server_type: Type[_Server] = server.default.PerClientStateServer,
+        server_type: Type[_Server] = find_builtin_server_type("PerClientStateServer"),
         host: str = "127.0.0.1",
         port: Optional[int] = None,
         server_config: Optional[Any] = None,

--- a/tests/test_server/test_base.py
+++ b/tests/test_server/test_base.py
@@ -1,7 +1,7 @@
 import pytest
 
 import idom
-from idom.server.default import PerClientStateServer
+from idom.server.utils import find_builtin_server_type
 
 
 def test_no_application_until_running():
@@ -9,7 +9,7 @@ def test_no_application_until_running():
     def AnyElement():
         pass
 
-    server = PerClientStateServer(AnyElement)
+    server = find_builtin_server_type("PerClientStateServer")(AnyElement)
 
     with pytest.raises(RuntimeError, match="No application"):
         server.application

--- a/tests/test_server/test_prefab.py
+++ b/tests/test_server/test_prefab.py
@@ -1,7 +1,7 @@
 import pytest
 
 import idom
-from idom.server.default import PerClientStateServer
+from idom.server.utils import find_builtin_server_type
 from idom.server.prefab import multiview_server
 from idom.testing import ServerMountPoint
 
@@ -11,7 +11,8 @@ from tests.driver_utils import no_such_element
 @pytest.fixture
 def server_mount_point():
     return ServerMountPoint(
-        PerClientStateServer, mount_and_server_constructor=multiview_server
+        find_builtin_server_type("PerClientStateServer"),
+        mount_and_server_constructor=multiview_server,
     )
 
 


### PR DESCRIPTION
Sanic was accidentally imported when not explicitely requested.
This means `pip install idom[sanic]` is currently required.
To avoid this we add a find_builtin_server_type() function to
help in testing and internal utilities.