### PR TITLE
Replace rstrip with correct handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on:
   push:
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "0 0 * * *"
 

--- a/idom/client/manage.py
+++ b/idom/client/manage.py
@@ -37,13 +37,13 @@ def web_module_exists(package_name: str) -> bool:
 def web_module_names() -> Set[str]:
     names = []
     for pth in WEB_MODULES_DIR.glob("**/*.js"):
-        for rel_pth in pth.relative_to(WEB_MODULES_DIR):
-            if Path("common") not in rel_pth.parents:
-                continue
-            module_path = str(rel_pth.as_posix())
-            if module_path.endswith('.js'):
-                module_path = module_path[:-3]
-            names.append(module_path)
+        rel_pth = pth.relative_to(WEB_MODULES_DIR)
+        if Path("common") in rel_pth.parents:
+            continue
+        module_path = str(rel_pth.as_posix())
+        if module_path.endswith('.js'):
+            module_path = module_path[:-3]
+        names.append(module_path)
     return set(names)
 
 

--- a/idom/client/manage.py
+++ b/idom/client/manage.py
@@ -41,7 +41,7 @@ def web_module_names() -> Set[str]:
         if Path("common") in rel_pth.parents:
             continue
         module_path = str(rel_pth.as_posix())
-        if module_path.endswith('.js'):
+        if module_path.endswith(".js"):
             module_path = module_path[:-3]
         names.append(module_path)
     return set(names)

--- a/idom/client/manage.py
+++ b/idom/client/manage.py
@@ -35,13 +35,16 @@ def web_module_exists(package_name: str) -> bool:
 
 
 def web_module_names() -> Set[str]:
-    return {
-        str(rel_pth.as_posix()).rstrip(".js")
-        for rel_pth in (
-            pth.relative_to(WEB_MODULES_DIR) for pth in WEB_MODULES_DIR.glob("**/*.js")
-        )
-        if Path("common") not in rel_pth.parents
-    }
+    names = []
+    for pth in WEB_MODULES_DIR.glob("**/*.js"):
+        for rel_pth in pth.relative_to(WEB_MODULES_DIR):
+            if Path("common") not in rel_pth.parents:
+                continue
+            module_path = str(rel_pth.as_posix())
+            if module_path.endswith('.js'):
+                module_path = module_path[:-3]
+            names.append(module_path)
+    return set(names)
 
 
 def add_web_module(package_name: str, source: Union[Path, str]) -> str:


### PR DESCRIPTION
This was causing various packages ending in `j` or `s` to have their names mangled and therefore not be found, e.g.:

```python
'react-sparklines.js'.rstrip('.js') == 'react-sparkline'
```