### PR TITLE
web_modules_dir needs to be public

### DIFF
--- a/src/idom/client/_private.py
+++ b/src/idom/client/_private.py
@@ -16,23 +16,15 @@ if not IDOM_CLIENT_BUILD_DIR.get().exists():  # pragma: no cover
     shutil.copytree(BACKUP_BUILD_DIR, IDOM_CLIENT_BUILD_DIR.get(), symlinks=True)
 
 
-def build_dir() -> Path:
-    return IDOM_CLIENT_BUILD_DIR.get()
-
-
-def web_modules_dir() -> Path:
-    return build_dir() / "_snowpack" / "pkg"
-
-
 def restore_build_dir_from_backup() -> None:
-    target = build_dir()
+    target = IDOM_CLIENT_BUILD_DIR.get()
     if target.exists():
         shutil.rmtree(target)
     shutil.copytree(BACKUP_BUILD_DIR, target, symlinks=True)
 
 
 def replace_build_dir(source: Path) -> None:
-    target = build_dir()
+    target = IDOM_CLIENT_BUILD_DIR.get()
     if target.exists():
         shutil.rmtree(target)
     shutil.copytree(source, target, symlinks=True)
@@ -58,7 +50,7 @@ def split_package_name_and_version(pkg: str) -> Tuple[str, str]:
 
 
 def build_dependencies() -> Dict[str, str]:
-    package_json = build_dir() / "package.json"
+    package_json = IDOM_CLIENT_BUILD_DIR.get() / "package.json"
     return cast(Dict[str, str], json.loads(package_json.read_text())["dependencies"])
 
 

--- a/src/idom/config.py
+++ b/src/idom/config.py
@@ -24,7 +24,12 @@ IDOM_CLIENT_BUILD_DIR = _option.Option(
     default=Path(__file__).parent / "client" / "build",
     validator=Path,
 )
-"""The location IDOM will use to store its client application"""
+"""The location IDOM will use to store its client application
+
+This directory **MUST** be treated as a black box. Downstream applications **MUST NOT**
+assume anything about the structure of this directory see :mod:`idom.client.manage` for
+a set of publically available APIs for working with the client.
+"""
 
 IDOM_CLIENT_WEB_MODULE_BASE_URL = _option.Option(
     "IDOM_CLIENT_WEB_MODULE_BASE_URL",


### PR DESCRIPTION
the web_modules_path func already is + we need it for
idom-jupyter to be able to distribute just the modules
without the client in a non-brittle way