### PR TITLE
rename hasMount to exportsMount

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -49,7 +49,7 @@ Yes, but with some restrictions:
 1. The Javascript in question must be distributed as an ECMAScript Module
    (`ESM <https://hacks.mozilla.org/2018/03/es-modules-a-cartoon-deep-dive/>`__)
 2. The module must export a ``mount(element, component, props)`` function
-3. Set ``has_mount=True`` when creating your :class:`~idom.client.module.Module`
+3. Set ``exports_mount=True`` when creating your :class:`~idom.client.module.Module`
    instance.
 
 These restrictions apply because the Javascript from the CDN must be able to run

--- a/src/idom/client/app/packages/idom-client-react/src/index.js
+++ b/src/idom/client/app/packages/idom-client-react/src/index.js
@@ -69,6 +69,7 @@ function ImportedElement({ model }) {
       mountImportSource(mountPoint.current, module, model, config);
     });
   });
+
   return html`<div ref=${mountPoint} />`;
 }
 
@@ -138,10 +139,7 @@ function eventHandler(sendEvent, eventSpec) {
 }
 
 function mountImportSource(element, module, model, config) {
-  if (model.importSource.hasMount) {
-    if (model.children) {
-      console.error("Mount function does not support children");
-    }
+  if (model.importSource.exportsMount) {
     const props = elementAttributes(model, config.sendEvent);
     if (model.children) {
       props.children = model.children;

--- a/src/idom/config.py
+++ b/src/idom/config.py
@@ -76,8 +76,8 @@ IDOM_CLIENT_MODULES_MUST_HAVE_MOUNT = _Option(
 
 Client implementations that do not support dynamically installed modules can set this
 option to block the usages of components that are not mounted in isolation. More
-specifically, this requires the ``has_mount`` option of :class:`~idom.client.module.Module`
-to be ``True``.
+specifically, this requires the ``exports_mount`` option of
+:class:`~idom.client.module.Module` to be ``True``.
 """
 
 IDOM_FEATURE_INDEX_AS_DEFAULT_KEY = _Option(

--- a/src/idom/core/vdom.py
+++ b/src/idom/core/vdom.py
@@ -58,7 +58,7 @@ VDOM_JSON_SCHEMA = {
                     "if": {"not": {"type": "null"}},
                     "then": {"$ref": "#/definitions/elementOrString"},
                 },
-                "hasMount": {"type": "boolean"},
+                "exportsMount": {"type": "boolean"},
             },
             "required": ["source"],
         },
@@ -84,7 +84,7 @@ def validate_vdom(value: Any) -> None:
 class ImportSourceDict(TypedDict):
     source: str
     fallback: Any
-    hasMount: bool  # noqa
+    exportsMount: bool  # noqa
 
 
 class _VdomDictOptional(TypedDict, total=False):

--- a/tests/test_client/test_app.py
+++ b/tests/test_client/test_app.py
@@ -50,7 +50,7 @@ def test_vanilla_js_component_with_mount(driver, display):
     vanilla_js_component = Module(
         "vanilla-js-component",
         source_file=HERE / "js" / "vanilla-js-component.js",
-        has_mount=True,
+        exports_mount=True,
     )
 
     @idom.component

--- a/tests/test_client/test_module.py
+++ b/tests/test_client/test_module.py
@@ -31,7 +31,7 @@ def test_any_relative_or_abolute_url_allowed():
 def test_module_import_repr():
     assert (
         repr(Module("/absolute/url/module").declare("SomeComponent"))
-        == "Import(name='SomeComponent', source='/absolute/url/module', fallback=None, hasMount=False)"
+        == "Import(name='SomeComponent', source='/absolute/url/module', fallback=None, exportsMount=False)"
     )
 
 
@@ -99,16 +99,18 @@ def test_idom_client_modules_must_have_mount():
             idom.Import(
                 "https://some.url",
                 "SomeComponent",
-                has_mount=False,
+                exports_mount=False,
             )
     finally:
         IDOM_CLIENT_MODULES_MUST_HAVE_MOUNT.current = old_opt
 
 
-def test_module_must_export_mount_if_has_mount_is_set():
-    with pytest.raises(ValueError, match="does not export 'mount' but has_mount=True"):
+def test_module_must_export_mount_if_exports_mount_is_set():
+    with pytest.raises(
+        ValueError, match="does not export 'mount' but exports_mount=True"
+    ):
         idom.Module(
             "component-without-mount",
             source_file=JS_FIXTURES / "component-without-mount.js",
-            has_mount=True,
+            exports_mount=True,
         )


### PR DESCRIPTION
also removes forgotten console.error for
having children if exportsMount