### PR TITLE
fix 417 and 413

### DIFF
--- a/docs/source/auto/api-reference.rst
+++ b/docs/source/auto/api-reference.rst
@@ -58,9 +58,6 @@ API Reference
 Misc Modules
 ------------
 
-.. automodule:: idom.core.utils
-    :members:
-
 .. automodule:: idom.server.proto
     :members:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -122,7 +122,6 @@ def test_suite(session: Session) -> None:
         session.log("Coverage won't be checked")
         session.install(".[all]")
     else:
-        session.log("Coverage will be checked")
         posargs += ["--cov=src/idom", "--cov-report", "term"]
         install_idom_dev(session, extras="all")
 

--- a/src/idom/core/events.py
+++ b/src/idom/core/events.py
@@ -14,6 +14,7 @@ from typing import (
     Optional,
     Union,
 )
+from uuid import uuid4
 
 from anyio import create_task_group
 
@@ -149,6 +150,7 @@ class EventHandler:
         "_func_handlers",
         "prevent_default",
         "stop_propagation",
+        "target",
     )
 
     def __init__(
@@ -156,10 +158,11 @@ class EventHandler:
         stop_propagation: bool = False,
         prevent_default: bool = False,
     ) -> None:
-        self.stop_propagation = stop_propagation
-        self.prevent_default = prevent_default
         self._coro_handlers: List[Callable[..., Coroutine[Any, Any, Any]]] = []
         self._func_handlers: List[Callable[..., Any]] = []
+        self.prevent_default = prevent_default
+        self.stop_propagation = stop_propagation
+        self.target = uuid4().hex
 
     def add(self, function: Callable[..., Any]) -> "EventHandler":
         """Add a callback function or coroutine to the event handler.
@@ -205,3 +208,8 @@ class EventHandler:
             return function in self._coro_handlers
         else:
             return function in self._func_handlers
+
+    def __repr__(self) -> str:
+        public_names = [name for name in self.__slots__ if not name.startswith("_")]
+        items = ", ".join([f"{n}={getattr(self, n)!r}" for n in public_names])
+        return f"{type(self).__name__}({items})"

--- a/src/idom/core/hooks.py
+++ b/src/idom/core/hooks.py
@@ -31,7 +31,7 @@ from typing_extensions import Protocol
 import idom
 from idom.utils import Ref
 
-from .component import AbstractComponent
+from .component import ComponentType
 
 
 __all__ = [
@@ -393,7 +393,7 @@ class LifeCycleHook:
     def __init__(
         self,
         layout: idom.core.layout.Layout,
-        component: AbstractComponent,
+        component: ComponentType,
     ) -> None:
         self.component = component
         self._layout = weakref.ref(layout)

--- a/src/idom/core/utils.py
+++ b/src/idom/core/utils.py
@@ -1,5 +1,0 @@
-from typing import Any
-
-
-def hex_id(obj: Any) -> str:
-    return format(id(obj), "x")

--- a/src/idom/server/flask.py
+++ b/src/idom/server/flask.py
@@ -24,7 +24,7 @@ from typing_extensions import TypedDict
 
 import idom
 from idom.config import IDOM_DEBUG_MODE, IDOM_WED_MODULES_DIR
-from idom.core.component import AbstractComponent, ComponentConstructor
+from idom.core.component import ComponentConstructor, ComponentType
 from idom.core.dispatcher import dispatch_single_view
 from idom.core.layout import LayoutEvent, LayoutUpdate
 
@@ -184,7 +184,7 @@ def _get_query_params(ws: WebSocket) -> Dict[str, Any]:
 
 
 def dispatch_single_view_in_thread(
-    component: AbstractComponent,
+    component: ComponentType,
     send: Callable[[Any], None],
     recv: Callable[[], Optional[LayoutEvent]],
 ) -> None:

--- a/src/idom/server/proto.py
+++ b/src/idom/server/proto.py
@@ -2,13 +2,9 @@ from __future__ import annotations
 
 from typing import Optional, TypeVar
 
+from typing_extensions import Protocol
+
 from idom.core.component import ComponentConstructor
-
-
-try:
-    from typing import Protocol
-except ImportError:  # pragma: no cover
-    from typing_extensions import Protocol  # type: ignore
 
 
 _App = TypeVar("_App")

--- a/src/idom/testing.py
+++ b/src/idom/testing.py
@@ -29,7 +29,6 @@ from selenium.webdriver.remote.webdriver import WebDriver
 from idom.config import IDOM_WED_MODULES_DIR
 from idom.core.events import EventHandler
 from idom.core.hooks import LifeCycleHook, current_hook
-from idom.core.utils import hex_id
 from idom.server.prefab import hotswap_server
 from idom.server.proto import Server, ServerFactory
 from idom.server.utils import find_available_port
@@ -281,7 +280,7 @@ class StaticEventHandler:
 
     @property
     def target(self) -> str:
-        return hex_id(self._handler)
+        return self._handler.target
 
     def use(self, function: Callable[..., Any]) -> EventHandler:
         self._handler.clear()

--- a/tests/test_core/test_component.py
+++ b/tests/test_core/test_component.py
@@ -1,5 +1,4 @@
 import idom
-from idom.core.utils import hex_id
 
 
 def test_component_repr():
@@ -9,7 +8,7 @@ def test_component_repr():
 
     mc1 = MyComponent(1, 2, 3, x=4, y=5)
 
-    expected = f"MyComponent({hex_id(mc1)}, a=1, b=(2, 3), c={{'x': 4, 'y': 5}})"
+    expected = f"MyComponent({mc1.id}, a=1, b=(2, 3), c={{'x': 4, 'y': 5}})"
     assert repr(mc1) == expected
 
     # not enough args supplied to function

--- a/tests/test_core/test_events.py
+++ b/tests/test_core/test_events.py
@@ -3,6 +3,14 @@ from idom import hooks
 from idom.core.events import EventHandler
 
 
+def test_event_handler_repr():
+    handler = EventHandler()
+    assert (
+        repr(handler)
+        == f"EventHandler(prevent_default=False, stop_propagation=False, target={handler.target!r})"
+    )
+
+
 def test_simple_events_object():
     events = idom.Events()
 

--- a/tests/test_core/test_layout.py
+++ b/tests/test_core/test_layout.py
@@ -6,7 +6,6 @@ import pytest
 
 import idom
 from idom.core.layout import LayoutEvent, LayoutUpdate
-from idom.core.utils import hex_id
 from idom.testing import HookCatcher, StaticEventHandler
 from tests.general_utils import assert_same_items
 
@@ -23,13 +22,13 @@ def test_layout_repr():
 
     my_component = MyComponent()
     layout = idom.Layout(my_component)
-    assert str(layout) == f"Layout(MyComponent({hex_id(my_component)}))"
+    assert str(layout) == f"Layout(MyComponent({my_component.id}))"
 
 
 def test_layout_expects_abstract_component():
-    with pytest.raises(TypeError, match="Expected an AbstractComponent"):
+    with pytest.raises(TypeError, match="Expected an ComponentType"):
         idom.Layout(None)
-    with pytest.raises(TypeError, match="Expected an AbstractComponent"):
+    with pytest.raises(TypeError, match="Expected an ComponentType"):
         idom.Layout(idom.html.div())
 
 
@@ -183,15 +182,15 @@ async def test_components_are_garbage_collected():
     @outer_component_hook.capture
     def Outer():
         component = idom.hooks.current_hook().component
-        live_components.add(id(component))
-        finalize(component, live_components.discard, id(component))
+        live_components.add(component.id)
+        finalize(component, live_components.discard, component.id)
         return Inner()
 
     @idom.component
     def Inner():
         component = idom.hooks.current_hook().component
-        live_components.add(id(component))
-        finalize(component, live_components.discard, id(component))
+        live_components.add(component.id)
+        finalize(component, live_components.discard, component.id)
         return idom.html.div()
 
     with idom.Layout(Outer()) as layout:


### PR DESCRIPTION
closes: 413, 417

no more use of the id() function to generate unique
IDs for component and event handlers within the layout.

also includes a minor change to use a protocol (rather than
inheritance) for the component base-class. isinstance()
will not be a perfect check of type compatibility, but it
should be close enough