### PR TITLE
warn if key is param of component render function

### DIFF
--- a/src/idom/core/component.py
+++ b/src/idom/core/component.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import abc
 import inspect
+import warnings
 from functools import wraps
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 from uuid import uuid4
@@ -31,6 +32,11 @@ def component(function: ComponentRenderFunction) -> Callable[..., "Component"]:
         inspect.Parameter.KEYWORD_ONLY,
         inspect.Parameter.POSITIONAL_OR_KEYWORD,
     )
+    if key_is_kwarg:  # pragma: no cover
+        warnings.warn(
+            f"Component render function {function} uses reserved parameter 'key' - this "
+            "will produce an error in a future release"
+        )
 
     @wraps(function)
     def constructor(*args: Any, key: Optional[Any] = None, **kwargs: Any) -> Component:


### PR DESCRIPTION
previously key was a required parameter if it was given when constructing the component. initially we thought that just making it optional would be fine. however, after some thought, this could lead to unexpected behavior when users don't want 'key' to indicate identity - if it were optional the user would not get any warning when this confusion occurred. As a result we will warn the user about this until, in a future release we raise an exception.