### PR TITLE
Enable standard JS scripts to be linked in as a module

### DIFF
--- a/src/client/packages/idom-client-react/src/component.js
+++ b/src/client/packages/idom-client-react/src/component.js
@@ -170,7 +170,15 @@ function loadFromImportSource(config, importSource) {
           unmountElement: module.unmountElement,
         };
       } else {
-        console.error(`${module} does not expose the required interfaces`);
+        console.error(
+          `${importSource.source} does not expose the required interfaces`
+        );
+        // results in a no-op
+        return {
+          createElement: () => null,
+          renderElement: () => null,
+          unmountElement: () => null,
+        };
       }
     });
 }

--- a/src/idom/html.py
+++ b/src/idom/html.py
@@ -118,6 +118,18 @@ Interactive Elements
 - :func:`menu`
 - :func:`menuitem`
 - :func:`summary`
+
+
+Document Metadata
+-----------------
+
+- :func:`title`
+- :func:`base`
+- :func:`style`
+- :func:`meta`
+- :func:`script`
+- :func:`noscript`
+- :func:`template`
 """
 
 from .core.vdom import make_vdom_constructor
@@ -216,3 +228,13 @@ dialog = make_vdom_constructor("dialog")
 menu = make_vdom_constructor("menu")
 menuitem = make_vdom_constructor("menuitem")
 summary = make_vdom_constructor("summary")
+
+# Document metadata
+
+title = make_vdom_constructor("title")
+base = make_vdom_constructor("base", allow_children=False)
+style = make_vdom_constructor("style")
+meta = make_vdom_constructor("meta", allow_children=False)
+script = make_vdom_constructor("script")
+noscript = make_vdom_constructor("noscript")
+template = make_vdom_constructor("template")

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -6,6 +6,8 @@ General Utilities
 from html.parser import HTMLParser as _HTMLParser
 from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, TypeVar
 
+from idom.core.vdom import VdomDict
+
 
 _RefValue = TypeVar("_RefValue")
 _UNDEFINED: Any = object()
@@ -57,7 +59,7 @@ class Ref(Generic[_RefValue]):
 _ModelTransform = Callable[[Dict[str, Any]], Any]
 
 
-def html_to_vdom(source: str, *transforms: _ModelTransform) -> Dict[str, Any]:
+def html_to_vdom(source: str, *transforms: _ModelTransform) -> VdomDict:
     """Transform HTML into a DOM model
 
     Parameters:

--- a/src/idom/web/utils.py
+++ b/src/idom/web/utils.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Set, Tuple
 from urllib.parse import urlparse
 
@@ -8,12 +8,6 @@ import requests
 
 
 logger = logging.getLogger(__name__)
-
-
-def module_name_suffix(name: str) -> str:
-    head, _, tail = name.partition("@")  # handle version identifier
-    version, _, tail = tail.partition("/")  # get section after version
-    return PurePosixPath(tail or head).suffix or ".js"
 
 
 def resolve_module_exports_from_file(file: Path, max_depth: int) -> Set[str]:

--- a/tests/js_fixtures/add-button-to-body.js
+++ b/tests/js_fixtures/add-button-to-body.js
@@ -1,0 +1,6 @@
+const button = document.createElement("button");
+button.setAttribute("id", "the-button");
+button.appendChild(document.createTextNode("click me!"));
+button.onclick = () => {document.body.removeChild(button)};
+
+document.body.appendChild(button);

--- a/tests/test_web/test_module.py
+++ b/tests/test_web/test_module.py
@@ -143,6 +143,29 @@ def test_web_module_from_file_symlink(tmp_path):
     assert module.file.resolve().read_text() == "hello world!"
 
 
+def test_module_from_source_string(driver, driver_wait, display):
+    SimpleButton = idom.web.export(
+        idom.web.module_from_source_string(
+            "simple-button", (JS_FIXTURES_DIR / "simple-button.js").read_text()
+        ),
+        "SimpleButton",
+    )
+
+    is_clicked = idom.Ref(False)
+
+    @idom.component
+    def ShowSimpleButton():
+        return SimpleButton(
+            {"id": "my-button", "onClick": lambda event: is_clicked.set_current(True)}
+        )
+
+    display(ShowSimpleButton)
+
+    button = driver.find_element_by_id("my-button")
+    button.click()
+    driver_wait.until(lambda d: is_clicked.current)
+
+
 def test_module_missing_exports():
     module = WebModule("test", NAME_SOURCE, None, {"a", "b", "c"}, None)
 


### PR DESCRIPTION
Fixes: #253

This accomplished by mildly abusing the custom component system.
In short, we create a no-op module interface so IDOM will load
the file, but won't actually do anything afterwards