### PR TITLE
clean up patch queues after exit

### DIFF
--- a/src/idom/__init__.py
+++ b/src/idom/__init__.py
@@ -1,6 +1,7 @@
 from . import config, html, log, web
 from .core import hooks
 from .core.component import Component, component
+from .core.dispatcher import Stop
 from .core.events import EventHandler, event
 from .core.layout import Layout
 from .core.vdom import vdom
@@ -27,6 +28,7 @@ __all__ = [
     "multiview",
     "Ref",
     "run",
+    "Stop",
     "vdom",
     "web",
 ]

--- a/tests/test_core/test_dispatcher.py
+++ b/tests/test_core/test_dispatcher.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 from typing import Any, Sequence
 
 import pytest
@@ -6,6 +7,7 @@ import pytest
 import idom
 from idom.core.dispatcher import (
     VdomJsonPatch,
+    _create_shared_view_dispatcher,
     create_shared_view_dispatcher,
     dispatch_single_view,
     ensure_shared_view_dispatcher_future,
@@ -39,7 +41,7 @@ def make_send_recv_callbacks(events_to_inject):
         changes.append(patch)
         sem.release()
         if not events_to_inject:
-            raise asyncio.CancelledError()
+            raise idom.Stop()
 
     async def recv():
         await sem.acquire()
@@ -130,3 +132,47 @@ async def test_ensure_shared_view_dispatcher_future():
 
     assert_changes_produce_expected_model(changes_1, model)
     assert_changes_produce_expected_model(changes_2, model)
+
+
+async def test_private_create_shared_view_dispatcher_cleans_up_patch_queues():
+    """Report an issue if this test breaks
+
+    Some internals of idom.core.dispatcher may need to be changed in order to make some
+    internal state easier to introspect.
+
+    Ideally we would just check if patch queues are getting cleaned up more directly,
+    but without having access to that, we use some side effects to try and infer whether
+    it happens.
+    """
+
+    @idom.component
+    def SomeComponent():
+        return idom.html.div()
+
+    async def send(patch):
+        raise idom.Stop()
+
+    async def recv():
+        return LayoutEvent("something", [])
+
+    with idom.Layout(SomeComponent()) as layout:
+        dispatch_shared_view, push_patch = await _create_shared_view_dispatcher(layout)
+
+        # Dispatch a view that should exit. After exiting its patch queue should be
+        # cleaned up and removed. Since we only dispatched one view there should be
+        # no patch queues.
+        await dispatch_shared_view(send, recv)  # this should stop immediately
+
+        # We create a patch and check its ref count. We will check this after attempting
+        # to push out the change.
+        patch = VdomJsonPatch("anything", [])
+        patch_ref_count = sys.getrefcount(patch)
+
+        # We push out this change.
+        push_patch(patch)
+
+        # Because there should be no patch queues, we expect that the ref count remains
+        # the same. If the ref count had increased, then we would know that the patch
+        # queue has not been cleaned up and that the patch we just pushed was added to
+        # it.
+        assert not sys.getrefcount(patch) > patch_ref_count


### PR DESCRIPTION
closes: #511 

also does some internal code cleanup and adds a dedicated Stop exception.