### PR TITLE
fix bug in element key identity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
         run: pip install -r requirements/nox-deps.txt
       - name: Run Tests
         env: { "CI": "true" }
-        run: nox -s test_python -- --headless --maxfail=3 --no-cov
+        run: nox -s test_python --stop-on-first-error -- --headless --maxfail=3 --no-cov
   test-docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         run: pip install -r requirements/nox-deps.txt
       - name: Run Tests
         env: { "CI": "true" }
-        run: nox -s test_python_suite -- --headless
+        run: nox -s test_python_suite -- --headless --maxfail=3
   test-python-environments:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -48,7 +48,7 @@ jobs:
         run: pip install -r requirements/nox-deps.txt
       - name: Run Tests
         env: { "CI": "true" }
-        run: nox -s test_python -- --headless --no-cov
+        run: nox -s test_python -- --headless --maxfail=3 --no-cov
   test-docs:
     runs-on: ubuntu-latest
     steps:

--- a/noxfile.py
+++ b/noxfile.py
@@ -181,6 +181,8 @@ def test_python_suite(session: Session) -> None:
     install_requirements_file(session, "test-env")
 
     posargs = session.posargs
+    posargs += ["--reruns", "3", "--reruns-delay", "1"]
+
     if "--no-cov" in session.posargs:
         session.log("Coverage won't be checked")
         session.install(".[all]")

--- a/requirements/pkg-deps.txt
+++ b/requirements/pkg-deps.txt
@@ -1,6 +1,6 @@
 typing-extensions >=3.10
 mypy-extensions >=0.4.3
 anyio >=3.0
-jsonpatch >=1.26
+jsonpatch >=1.32
 fastjsonschema >=2.14.5
 requests >=2.0

--- a/requirements/test-env.txt
+++ b/requirements/test-env.txt
@@ -1,8 +1,9 @@
+ipython
 pytest
 pytest-asyncio
 pytest-cov
 pytest-mock
+pytest-rerunfailures
 pytest-timeout
-selenium
-ipython
 responses
+selenium

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ exclude_lines =
     raise NotImplementedError
 omit =
     src/idom/__main__.py
+    src/idom/core/_fixed_jsonpatch.py
 
 [build_sphinx]
 all-files = true

--- a/src/idom/core/_fixed_jsonpatch.py
+++ b/src/idom/core/_fixed_jsonpatch.py
@@ -9,36 +9,28 @@ that's been copied over with little to no changes.
 from jsonpatch import _ST_REMOVE
 from jsonpatch import DiffBuilder as _DiffBuilder
 from jsonpatch import JsonPatch as _JsonPatch
-from jsonpatch import JsonPointer, RemoveOperation, _path_join
+from jsonpatch import RemoveOperation, _path_join
 
 
-def apply_patch(doc, patch, in_place=False, pointer_cls=JsonPointer):
+def apply_patch(doc, patch, in_place=False):
     if isinstance(patch, (str, bytes)):
-        patch = JsonPatch.from_string(patch, pointer_cls=pointer_cls)
+        patch = JsonPatch.from_string(patch)
     else:
-        patch = JsonPatch(patch, pointer_cls=pointer_cls)
+        patch = JsonPatch(patch)
     return patch.apply(doc, in_place)
 
 
-def make_patch(src, dst, pointer_cls=JsonPointer):
-    return JsonPatch.from_diff(src, dst, pointer_cls=pointer_cls)
+def make_patch(src, dst):
+    return JsonPatch.from_diff(src, dst)
 
 
 class JsonPatch(_JsonPatch):
     @classmethod
-    def from_diff(
-        cls,
-        src,
-        dst,
-        optimization=True,
-        dumps=None,
-        pointer_cls=JsonPointer,
-    ):
-        json_dumper = dumps or cls.json_dumper
-        builder = DiffBuilder(src, dst, json_dumper, pointer_cls=pointer_cls)
+    def from_diff(cls, src, dst, optimization=True):
+        builder = DiffBuilder()
         builder._compare_values("", None, src, dst)
         ops = list(builder.execute())
-        return cls(ops, pointer_cls=pointer_cls)
+        return cls(ops)
 
 
 class DiffBuilder(_DiffBuilder):
@@ -47,8 +39,7 @@ class DiffBuilder(_DiffBuilder):
             {
                 "op": "remove",
                 "path": _path_join(path, key),
-            },
-            pointer_cls=self.pointer_cls,
+            }
         )
         new_index = self.insert(new_op)
         self.store_index(item, new_index, _ST_REMOVE)

--- a/src/idom/core/_fixed_jsonpatch.py
+++ b/src/idom/core/_fixed_jsonpatch.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 """A patched version of jsonpatch
 
 We need this because of: https://github.com/stefankoegl/python-json-patch/issues/138
@@ -9,28 +11,37 @@ that's been copied over with little to no changes.
 from jsonpatch import _ST_REMOVE
 from jsonpatch import DiffBuilder as _DiffBuilder
 from jsonpatch import JsonPatch as _JsonPatch
-from jsonpatch import RemoveOperation, _path_join
+from jsonpatch import RemoveOperation, _path_join, basestring
+from jsonpointer import JsonPointer
 
 
-def apply_patch(doc, patch, in_place=False):
-    if isinstance(patch, (str, bytes)):
-        patch = JsonPatch.from_string(patch)
+def apply_patch(doc, patch, in_place=False, pointer_cls=JsonPointer):
+    if isinstance(patch, basestring):
+        patch = JsonPatch.from_string(patch, pointer_cls=pointer_cls)
     else:
-        patch = JsonPatch(patch)
+        patch = JsonPatch(patch, pointer_cls=pointer_cls)
     return patch.apply(doc, in_place)
 
 
-def make_patch(src, dst):
-    return JsonPatch.from_diff(src, dst)
+def make_patch(src, dst, pointer_cls=JsonPointer):
+    return JsonPatch.from_diff(src, dst, pointer_cls=pointer_cls)
 
 
 class JsonPatch(_JsonPatch):
     @classmethod
-    def from_diff(cls, src, dst, optimization=True):
-        builder = DiffBuilder()
+    def from_diff(
+        cls,
+        src,
+        dst,
+        optimization=True,
+        dumps=None,
+        pointer_cls=JsonPointer,
+    ):
+        json_dumper = dumps or cls.json_dumper
+        builder = DiffBuilder(src, dst, json_dumper, pointer_cls=pointer_cls)
         builder._compare_values("", None, src, dst)
         ops = list(builder.execute())
-        return cls(ops)
+        return cls(ops, pointer_cls=pointer_cls)
 
 
 class DiffBuilder(_DiffBuilder):

--- a/src/idom/core/_fixed_jsonpatch.py
+++ b/src/idom/core/_fixed_jsonpatch.py
@@ -1,0 +1,54 @@
+"""A patched version of jsonpatch
+
+We need this because of: https://github.com/stefankoegl/python-json-patch/issues/138
+
+The core of this patch is in `DiffBuilder._item_removed`. The rest is just boilerplate
+that's been copied over with little to no changes.
+"""
+
+from jsonpatch import _ST_REMOVE
+from jsonpatch import DiffBuilder as _DiffBuilder
+from jsonpatch import JsonPatch as _JsonPatch
+from jsonpatch import JsonPointer, RemoveOperation, _path_join
+
+
+def apply_patch(doc, patch, in_place=False, pointer_cls=JsonPointer):
+    if isinstance(patch, (str, bytes)):
+        patch = JsonPatch.from_string(patch, pointer_cls=pointer_cls)
+    else:
+        patch = JsonPatch(patch, pointer_cls=pointer_cls)
+    return patch.apply(doc, in_place)
+
+
+def make_patch(src, dst, pointer_cls=JsonPointer):
+    return JsonPatch.from_diff(src, dst, pointer_cls=pointer_cls)
+
+
+class JsonPatch(_JsonPatch):
+    @classmethod
+    def from_diff(
+        cls,
+        src,
+        dst,
+        optimization=True,
+        dumps=None,
+        pointer_cls=JsonPointer,
+    ):
+        json_dumper = dumps or cls.json_dumper
+        builder = DiffBuilder(src, dst, json_dumper, pointer_cls=pointer_cls)
+        builder._compare_values("", None, src, dst)
+        ops = list(builder.execute())
+        return cls(ops, pointer_cls=pointer_cls)
+
+
+class DiffBuilder(_DiffBuilder):
+    def _item_removed(self, path, key, item):
+        new_op = RemoveOperation(
+            {
+                "op": "remove",
+                "path": _path_join(path, key),
+            },
+            pointer_cls=self.pointer_cls,
+        )
+        new_index = self.insert(new_op)
+        self.store_index(item, new_index, _ST_REMOVE)

--- a/src/idom/core/dispatcher.py
+++ b/src/idom/core/dispatcher.py
@@ -19,10 +19,10 @@ from typing import (
 from weakref import WeakSet
 
 from anyio import create_task_group
-from jsonpatch import apply_patch, make_patch
 
 from idom.utils import Ref
 
+from ._fixed_jsonpatch import apply_patch, make_patch
 from .layout import LayoutEvent, LayoutUpdate
 from .proto import LayoutType, VdomJson
 

--- a/src/idom/core/dispatcher.py
+++ b/src/idom/core/dispatcher.py
@@ -22,7 +22,7 @@ from anyio import create_task_group
 
 from idom.utils import Ref
 
-from ._fixed_jsonpatch import apply_patch, make_patch
+from ._fixed_jsonpatch import apply_patch, make_patch  # type: ignore
 from .layout import LayoutEvent, LayoutUpdate
 from .proto import LayoutType, VdomJson
 

--- a/src/idom/core/layout.py
+++ b/src/idom/core/layout.py
@@ -538,7 +538,7 @@ def _update_element_model_state(
         key=old_model_state.key,
         model=Ref(),  # does not copy the model
         patch_path=old_model_state.patch_path,
-        children_by_key=old_model_state.children_by_key.copy(),
+        children_by_key={},
         targets_by_event={},
     )
 

--- a/src/idom/core/layout.py
+++ b/src/idom/core/layout.py
@@ -217,10 +217,9 @@ class Layout:
         else:
             key, index = new_state.key, new_state.index
             if old_state is not None:
-                assert (key, index) == (old_state.key, old_state.index,), (
+                assert key == old_state.key, (
                     "state mismatch during component update - "
-                    f"key {key!r}!={old_state.key} "
-                    f"or index {index}!={old_state.index}"
+                    f"key {key!r}!={old_state.key!r} "
                 )
             parent.children_by_key[key] = new_state
             # need to do insertion in case where old_state is None and we're appending

--- a/src/idom/log.py
+++ b/src/idom/log.py
@@ -1,17 +1,12 @@
 import logging
 import sys
 from logging.config import dictConfig
-from typing import Any
 
 from .config import IDOM_DEBUG_MODE
 
 
-root_logger = logging.getLogger("idom")
-
-
-def logging_config_defaults() -> Any:
-    """Get default logging configuration"""
-    return {
+dictConfig(
+    {
         "version": 1,
         "disable_existing_loggers": False,
         "loggers": {
@@ -35,10 +30,12 @@ def logging_config_defaults() -> Any:
             }
         },
     }
+)
 
 
-dictConfig(logging_config_defaults())
+ROOT_LOGGER = logging.getLogger("idom")
+"""IDOM's root logger instance"""
 
 
 if IDOM_DEBUG_MODE.current:
-    root_logger.debug("IDOM is in debug mode")
+    ROOT_LOGGER.debug("IDOM is in debug mode")

--- a/src/idom/testing.py
+++ b/src/idom/testing.py
@@ -224,7 +224,7 @@ def assert_idom_logged(
                 if clear_matched_records:
                     handler.records.remove(record)
 
-        if not found:
+        if not found:  # pragma: no cover
             conditions = []
             if match_message:
                 conditions.append(f"log message pattern {match_message!r}")

--- a/src/idom/testing.py
+++ b/src/idom/testing.py
@@ -202,9 +202,10 @@ def assert_idom_logged(
                 message_pattern.findall(record.getMessage())
                 # error type matches
                 and (
-                    not error_type
+                    error_type is None
                     or (
                         record.exc_info is not None
+                        and record.exc_info[0] is not None
                         and issubclass(record.exc_info[0], error_type)
                     )
                 )

--- a/tests/test_core/test_layout.py
+++ b/tests/test_core/test_layout.py
@@ -142,25 +142,33 @@ async def test_layout_render_error_has_partial_update_with_error_message():
 
     @idom.component
     def BadChild():
-        raise ValueError("Something went wrong :(")
+        raise ValueError("error from bad child")
 
-    with idom.Layout(Main()) as layout:
-        patch = await render_json_patch(layout)
-        assert_same_items(
-            patch.changes,
-            [
-                {
-                    "op": "add",
-                    "path": "/children",
-                    "value": [
-                        {"tagName": "div", "children": ["hello"]},
-                        {"tagName": "", "error": "ValueError: Something went wrong :("},
-                        {"tagName": "div", "children": ["hello"]},
-                    ],
-                },
-                {"op": "add", "path": "/tagName", "value": "div"},
-            ],
-        )
+    with assert_idom_logged(
+        match_error="error from bad child",
+        clear_matched_records=True,
+    ):
+
+        with idom.Layout(Main()) as layout:
+            patch = await render_json_patch(layout)
+            assert_same_items(
+                patch.changes,
+                [
+                    {
+                        "op": "add",
+                        "path": "/children",
+                        "value": [
+                            {"tagName": "div", "children": ["hello"]},
+                            {
+                                "tagName": "",
+                                "error": "ValueError: error from bad child",
+                            },
+                            {"tagName": "div", "children": ["hello"]},
+                        ],
+                    },
+                    {"op": "add", "path": "/tagName", "value": "div"},
+                ],
+            )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
closes: #556 

Includes a fix for https://github.com/stefankoegl/python-json-patch/issues/138 in `jsonpatch` 

Additionally, we were copying the `children_by_key` dictionary when updating elements.