### PR TITLE
fix issue with key-based identity

### DIFF
--- a/src/idom/core/layout.py
+++ b/src/idom/core/layout.py
@@ -611,7 +611,7 @@ class _ModelState:
         assert parent is not None, "detached model state"
         return parent
 
-    def __repr__(self) -> str:
+    def __repr__(self) -> str:  # pragma: no cover
         return f"ModelState({ {s: getattr(self, s, None) for s in self.__slots__} })"
 
 

--- a/src/idom/core/layout.py
+++ b/src/idom/core/layout.py
@@ -234,14 +234,21 @@ class Layout:
         raw_model: Any,
     ) -> None:
         new_state.model.current = {"tagName": raw_model["tagName"]}
+        if "key" in raw_model:
+            new_state.key = new_state.model.current["key"] = raw_model["key"]
+        if "importSource" in raw_model:
+            new_state.model.current["importSource"] = raw_model["importSource"]
+
+        if old_state is not None and old_state.key != new_state.key:
+            self._unmount_model_states([old_state])
+            if new_state.is_component_state:
+                self._model_states_by_life_cycle_state_id[
+                    new_state.life_cycle_state.id
+                ] = new_state
+            old_state = None
 
         self._render_model_attributes(old_state, new_state, raw_model)
         self._render_model_children(old_state, new_state, raw_model.get("children", []))
-
-        if "key" in raw_model:
-            new_state.model.current["key"] = raw_model["key"]
-        if "importSource" in raw_model:
-            new_state.model.current["importSource"] = raw_model["importSource"]
 
     def _render_model_attributes(
         self,
@@ -603,6 +610,9 @@ class _ModelState:
         parent = self._parent_ref()
         assert parent is not None, "detached model state"
         return parent
+
+    def __repr__(self) -> str:
+        return f"ModelState({ {s: getattr(self, s, None) for s in self.__slots__} })"
 
 
 def _make_life_cycle_state(

--- a/temp.py
+++ b/temp.py
@@ -1,0 +1,23 @@
+from random import random
+
+from idom import component, hooks, html, run
+
+
+@component
+def Demo():
+    h = hooks.current_hook()
+    print("render")
+    return html.div(
+        html.button({"onClick": lambda event: h.schedule_render()}, "re-render"),
+        HasState(),
+        key=str(random()),
+    )
+
+
+@component
+def HasState():
+    state = hooks.use_state(random)[0]
+    return html.p(state)
+
+
+run(Demo)


### PR DESCRIPTION
closes: #622 

keys for elements at the root of a component were not being tracked. thus key changes for elements at the root did not trigger unmounts.

The logic inside of `layout.py` is becoming increasingly convoluted. it needs to be refactored. Thankfully we have an extensive library of tests which we can use to prevent regressions once there's time to do that.