### PR TITLE
actually fix #684

### DIFF
--- a/docs/source/_custom_js/package-lock.json
+++ b/docs/source/_custom_js/package-lock.json
@@ -19,7 +19,7 @@
       }
     },
     "../../../src/client/packages/idom-client-react": {
-      "version": "0.37.0",
+      "version": "0.37.1-a1",
       "integrity": "sha512-pIK5eNwFSHKXg7ClpASWFVKyZDYxz59MSFpVaX/OqJFkrJaAxBuhKGXNTMXmuyWOL5Iyvb/ErwwDRxQRzMNkfQ==",
       "license": "MIT",
       "dependencies": {

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -16,7 +16,9 @@ scheme for the project adheres to `Semantic Versioning <https://semver.org/>`__.
 Unreleased
 ----------
 
-Nothing yet...
+Fixed:
+
+- Revert :pull:`694` and by making ``value`` uncontrolled client-side - :issue:`684`
 
 
 0.37.1-a1
@@ -24,7 +26,7 @@ Nothing yet...
 
 Fixed:
 
-- ``onChange`` event for inputs missing key strokes :issue:`684`
+- ``onChange`` event for inputs missing key strokes - :issue:`684`
 
 
 0.37.0

--- a/src/client/packages/idom-client-react/src/element-utils.js
+++ b/src/client/packages/idom-client-react/src/element-utils.js
@@ -39,8 +39,6 @@ function createEventHandler(eventName, sendEvent, eventSpec) {
       if (typeof value === "object" && value.nativeEvent) {
         if (eventSpec["preventDefault"]) {
           value.preventDefault();
-        } else if (eventName === "onChange") {
-          value.nativeEvent.target.value = value.target.value;
         }
         if (eventSpec["stopPropagation"]) {
           value.stopPropagation();


### PR DESCRIPTION
closes: #684 

Because we handle events asynchronously, we must leave the value
uncontrolled in order to allow all changed committed by the user to be
recorded in the order they occur. If we don't, the user may commit
multiple changes before we render resulting in prior changes being
overwritten by subsequent ones. Instead of controlling the value, we set
it in an effect. This feels a bit hacky, but I can't think of a better
way to work around this problem.