### PR TITLE
Fix idom.run and more renaming of server to backend

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@ A summary of the changes.
 
 Please update this checklist as you complete each item:
 
-- [ ] Tests have been included for all bug fixes or new functionality.
+- [ ] Tests have been included for all bug fixes or added functionality.
 - [ ] The `changelog.rst` has been updated with any significant changes.
 - [ ] GitHub Issues which may be closed by this Pull Request have been linked.
+- [ ] I have left irrelevant checklist items unchecked instead of removing them.

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -23,7 +23,18 @@ more info, see the :ref:`Contributor Guide <Creating a Changelog Entry>`.
 Unreleased
 ----------
 
-No changes.
+**Fixed**
+
+- :pull:`763` - ``No module named 'idom.server'`` from ``idom.run``
+- :pull:`749` - Setting appropriate MIME type for web modules in `sanic` server implementation
+
+**Changed**
+
+- :pull:`763` - renamed various:
+
+  - ``idom.testing.server -> idom.testing.backend``
+  - ``ServerFixture -> BackendFixture``
+  - ``DisplayFixture.server -> DisplayFixture.backend``
 
 
 v0.38.1

--- a/src/idom/backend/fastapi.py
+++ b/src/idom/backend/fastapi.py
@@ -6,25 +6,25 @@ from . import starlette
 
 
 serve_development_app = starlette.serve_development_app
-"""Alias for :func:`idom.server.starlette.serve_development_app`"""
+"""Alias for :func:`idom.backend.starlette.serve_development_app`"""
 
 # see: https://github.com/idom-team/flake8-idom-hooks/issues/12
 use_location = starlette.use_location  # noqa: ROH101
-"""Alias for :func:`idom.server.starlette.use_location`"""
+"""Alias for :func:`idom.backend.starlette.use_location`"""
 
 # see: https://github.com/idom-team/flake8-idom-hooks/issues/12
 use_scope = starlette.use_scope  # noqa: ROH101
-"""Alias for :func:`idom.server.starlette.use_scope`"""
+"""Alias for :func:`idom.backend.starlette.use_scope`"""
 
 # see: https://github.com/idom-team/flake8-idom-hooks/issues/12
 use_websocket = starlette.use_websocket  # noqa: ROH101
-"""Alias for :func:`idom.server.starlette.use_websocket`"""
+"""Alias for :func:`idom.backend.starlette.use_websocket`"""
 
 Options = starlette.Options
-"""Alias for :class:`idom.server.starlette.Options`"""
+"""Alias for :class:`idom.backend.starlette.Options`"""
 
 configure = starlette.configure
-"""Alias for :class:`idom.server.starlette.configure`"""
+"""Alias for :class:`idom.backend.starlette.configure`"""
 
 
 def create_development_app() -> FastAPI:

--- a/src/idom/backend/flask.py
+++ b/src/idom/backend/flask.py
@@ -45,14 +45,12 @@ ConnectionContext: type[Context[Connection | None]] = create_context(
 def configure(
     app: Flask, component: RootComponentConstructor, options: Options | None = None
 ) -> None:
-    """Return a :class:`FlaskServer` where each client has its own state.
-
-    Implements the :class:`~idom.server.proto.ServerFactory` protocol
+    """Configure the necessary IDOM routes on the given app.
 
     Parameters:
-        constructor: A component constructor
+        app: An application instance
+        component: A component constructor
         options: Options for configuring server behavior
-        app: An application instance (otherwise a default instance is created)
     """
     options = options or Options()
     blueprint = Blueprint("idom", __name__, url_prefix=options.url_prefix)

--- a/src/idom/backend/starlette.py
+++ b/src/idom/backend/starlette.py
@@ -40,13 +40,11 @@ def configure(
     constructor: RootComponentConstructor,
     options: Options | None = None,
 ) -> None:
-    """Return a :class:`StarletteServer` where each client has its own state.
-
-    Implements the :class:`~idom.server.proto.ServerFactory` protocol
+    """Configure the necessary IDOM routes on the given app.
 
     Parameters:
         app: An application instance
-        constructor: A component constructor
+        component: A component constructor
         options: Options for configuring server behavior
     """
     options = options or Options()

--- a/src/idom/backend/tornado.py
+++ b/src/idom/backend/tornado.py
@@ -36,14 +36,12 @@ def configure(
     component: ComponentConstructor,
     options: Options | None = None,
 ) -> None:
-    """Return a :class:`TornadoServer` where each client has its own state.
-
-    Implements the :class:`~idom.server.proto.ServerFactory` protocol
+    """Configure the necessary IDOM routes on the given app.
 
     Parameters:
-        app: A tornado ``Application`` instance.
-        component: A root component constructor
-        options: Options for configuring how the component is mounted to the server.
+        app: An application instance
+        component: A component constructor
+        options: Options for configuring server behavior
     """
     options = options or Options()
     _add_handler(

--- a/src/idom/backend/utils.py
+++ b/src/idom/backend/utils.py
@@ -40,7 +40,7 @@ def run(
         "Change this before deploying in production!"
     )
 
-    implementation = implementation or import_module("idom.server.default")
+    implementation = implementation or import_module("idom.backend.default")
 
     app = implementation.create_development_app()
     implementation.configure(app, component)

--- a/src/idom/testing/__init__.py
+++ b/src/idom/testing/__init__.py
@@ -1,3 +1,4 @@
+from .backend import BackendFixture
 from .common import HookCatcher, StaticEventHandler, clear_idom_web_modules_dir, poll
 from .display import DisplayFixture
 from .logs import (
@@ -6,7 +7,6 @@ from .logs import (
     assert_idom_did_not_log,
     capture_idom_logs,
 )
-from .server import ServerFixture
 
 
 __all__ = [
@@ -18,6 +18,6 @@ __all__ = [
     "HookCatcher",
     "LogAssertionError",
     "poll",
-    "ServerFixture",
+    "BackendFixture",
     "StaticEventHandler",
 ]

--- a/src/idom/testing/backend.py
+++ b/src/idom/testing/backend.py
@@ -15,7 +15,7 @@ from idom.widgets import hotswap
 from .logs import LogAssertionError, capture_idom_logs, list_logged_exceptions
 
 
-class ServerFixture:
+class BackendFixture:
     """A test fixture for running a server and imperatively displaying views
 
     This fixture is typically used alongside async web drivers like ``playwight``.
@@ -23,7 +23,7 @@ class ServerFixture:
     Example:
         .. code-block::
 
-            async with ServerFixture() as server:
+            async with BackendFixture() as server:
                 server.mount(MyComponent)
     """
 
@@ -99,7 +99,7 @@ class ServerFixture:
             del_log_records,
         )
 
-    async def __aenter__(self) -> ServerFixture:
+    async def __aenter__(self) -> BackendFixture:
         self._exit_stack = AsyncExitStack()
         self._records = self._exit_stack.enter_context(capture_idom_logs())
 

--- a/src/idom/testing/display.py
+++ b/src/idom/testing/display.py
@@ -9,7 +9,7 @@ from playwright.async_api import Browser, BrowserContext, Page, async_playwright
 from idom import html
 from idom.types import RootComponentConstructor
 
-from .server import ServerFixture
+from .backend import BackendFixture
 
 
 class DisplayFixture:
@@ -19,11 +19,11 @@ class DisplayFixture:
 
     def __init__(
         self,
-        server: ServerFixture | None = None,
+        backend: BackendFixture | None = None,
         driver: Browser | BrowserContext | Page | None = None,
     ) -> None:
-        if server is not None:
-            self.server = server
+        if backend is not None:
+            self.backend = backend
         if driver is not None:
             if isinstance(driver, Page):
                 self.page = driver
@@ -37,13 +37,13 @@ class DisplayFixture:
     ) -> None:
         self._next_view_id += 1
         view_id = f"display-{self._next_view_id}"
-        self.server.mount(lambda: html.div({"id": view_id}, component()))
+        self.backend.mount(lambda: html.div({"id": view_id}, component()))
 
         await self.goto("/")
         await self.page.wait_for_selector(f"#{view_id}", state="attached")
 
     async def goto(self, path: str, query: Any | None = None) -> None:
-        await self.page.goto(self.server.url(path, query))
+        await self.page.goto(self.backend.url(path, query))
 
     async def __aenter__(self) -> DisplayFixture:
         es = self._exit_stack = AsyncExitStack()
@@ -57,9 +57,9 @@ class DisplayFixture:
                 browser = self._browser
             self.page = await browser.new_page()
 
-        if not hasattr(self, "server"):
-            self.server = ServerFixture()
-            await es.enter_async_context(self.server)
+        if not hasattr(self, "backend"):
+            self.backend = BackendFixture()
+            await es.enter_async_context(self.backend)
 
         return self
 
@@ -69,5 +69,5 @@ class DisplayFixture:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        self.server.mount(None)
+        self.backend.mount(None)
         await self._exit_stack.aclose()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,8 @@ from playwright.async_api import async_playwright
 
 from idom.config import IDOM_TESTING_DEFAULT_TIMEOUT
 from idom.testing import (
+    BackendFixture,
     DisplayFixture,
-    ServerFixture,
     capture_idom_logs,
     clear_idom_web_modules_dir,
 )
@@ -34,7 +34,7 @@ async def display(server, page):
 
 @pytest.fixture(scope="session")
 async def server():
-    async with ServerFixture() as server:
+    async with BackendFixture() as server:
         yield server
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from playwright.async_api import Browser
 
 import idom
-from idom.testing import DisplayFixture, ServerFixture
+from idom.testing import BackendFixture, DisplayFixture
 
 
 JS_DIR = Path(__file__).parent / "js"
@@ -22,7 +22,7 @@ async def test_automatic_reconnect(browser: Browser):
         return idom.html.p({"id": "old-component"}, "old")
 
     async with AsyncExitStack() as exit_stack:
-        server = await exit_stack.enter_async_context(ServerFixture(port=8000))
+        server = await exit_stack.enter_async_context(BackendFixture(port=8000))
         display = await exit_stack.enter_async_context(
             DisplayFixture(server, driver=page)
         )
@@ -43,7 +43,7 @@ async def test_automatic_reconnect(browser: Browser):
         return idom.html.p({"id": f"new-component-{state}"}, f"new-{state}")
 
     async with AsyncExitStack() as exit_stack:
-        server = await exit_stack.enter_async_context(ServerFixture(port=8000))
+        server = await exit_stack.enter_async_context(BackendFixture(port=8000))
         display = await exit_stack.enter_async_context(
             DisplayFixture(server, driver=page)
         )

--- a/tests/test_server/test_common.py
+++ b/tests/test_server/test_common.py
@@ -7,7 +7,7 @@ from idom import html
 from idom.backend import default as default_implementation
 from idom.backend.types import Location
 from idom.backend.utils import all_implementations
-from idom.testing import DisplayFixture, ServerFixture, poll
+from idom.testing import BackendFixture, DisplayFixture, poll
 
 
 @pytest.fixture(
@@ -16,8 +16,8 @@ from idom.testing import DisplayFixture, ServerFixture, poll
     scope="module",
 )
 async def display(page, request):
-    async with ServerFixture(implementation=request.param) as server:
-        async with DisplayFixture(server=server, driver=page) as display:
+    async with BackendFixture(implementation=request.param) as server:
+        async with DisplayFixture(backend=server, driver=page) as display:
             yield display
 
 
@@ -69,7 +69,7 @@ async def test_use_scope(display: DisplayFixture):
 
     @idom.component
     def ShowScope():
-        scope.current = display.server.implementation.use_scope()
+        scope.current = display.backend.implementation.use_scope()
         return html.pre({"id": "scope"}, str(scope.current))
 
     await display.show(ShowScope)
@@ -88,7 +88,7 @@ async def test_use_location(display: DisplayFixture):
 
     @idom.component
     def ShowRoute():
-        location.current = display.server.implementation.use_location()
+        location.current = display.backend.implementation.use_location()
         return html.pre({"id": "scope"}, str(location.current))
 
     await display.show(ShowRoute)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -141,9 +141,9 @@ def test_if_app_is_given_implementation_must_be_too():
         ValueError,
         match=r"If an application instance its corresponding server implementation must be provided too",
     ):
-        testing.ServerFixture(app=starlette_implementation.create_development_app())
+        testing.BackendFixture(app=starlette_implementation.create_development_app())
 
-    testing.ServerFixture(
+    testing.BackendFixture(
         app=starlette_implementation.create_development_app(),
         implementation=starlette_implementation,
     )

--- a/tests/test_web/test_module.py
+++ b/tests/test_web/test_module.py
@@ -6,8 +6,8 @@ from sanic import Sanic
 import idom
 from idom.backend import sanic as sanic_implementation
 from idom.testing import (
+    BackendFixture,
     DisplayFixture,
-    ServerFixture,
     assert_idom_did_log,
     assert_idom_did_not_log,
     poll,
@@ -70,7 +70,7 @@ async def test_module_from_url(browser):
     def ShowSimpleButton():
         return SimpleButton({"id": "my-button"})
 
-    async with ServerFixture(app=app, implementation=sanic_implementation) as server:
+    async with BackendFixture(app=app, implementation=sanic_implementation) as server:
         async with DisplayFixture(server, browser) as display:
             await display.show(ShowSimpleButton)
 


### PR DESCRIPTION
# Description

Renames `idom.server` to `idom.backend` also renamed `ServerFixture` to `BackendFixture` + `DisplayFixture.server` to `DisplayFixture.backend`.

# Checklist:

Please update this checklist as you complete each item:

- [x] Tests have been included for all bug fixes or new functionality.
- [x] The `changelog.rst` has been updated with any significant changes.
- [ ] GitHub Issues which may be closed by this Pull Request have been linked.
