### PR TITLE
use standard context provider pattern

### DIFF
--- a/src/idom/backend/flask.py
+++ b/src/idom/backend/flask.py
@@ -26,7 +26,7 @@ from werkzeug.serving import BaseWSGIServer, make_server
 
 import idom
 from idom.backend.types import Location
-from idom.core.hooks import Context, create_context, use_context
+from idom.core.hooks import ContextType, create_context, use_context
 from idom.core.layout import LayoutEvent, LayoutUpdate
 from idom.core.serve import serve_json_patch
 from idom.core.types import ComponentType, RootComponentConstructor
@@ -37,9 +37,7 @@ from .utils import safe_client_build_dir_path, safe_web_modules_dir_path
 
 logger = logging.getLogger(__name__)
 
-ConnectionContext: type[Context[Connection | None]] = create_context(
-    None, "ConnectionContext"
-)
+ConnectionContext: ContextType[Connection | None] = create_context(None, "connection")
 
 
 def configure(

--- a/src/idom/backend/sanic.py
+++ b/src/idom/backend/sanic.py
@@ -15,7 +15,7 @@ from sanic_cors import CORS
 from websockets.legacy.protocol import WebSocketCommonProtocol
 
 from idom.backend.types import Location
-from idom.core.hooks import Context, create_context, use_context
+from idom.core.hooks import ContextType, create_context, use_context
 from idom.core.layout import Layout, LayoutEvent
 from idom.core.serve import (
     RecvCoroutine,
@@ -32,9 +32,7 @@ from .utils import safe_client_build_dir_path, safe_web_modules_dir_path
 
 logger = logging.getLogger(__name__)
 
-ConnectionContext: type[Context[Connection | None]] = create_context(
-    None, "ConnectionContext"
-)
+ConnectionContext: ContextType[Connection | None] = create_context(None, "connection")
 
 
 def configure(

--- a/src/idom/backend/starlette.py
+++ b/src/idom/backend/starlette.py
@@ -14,7 +14,7 @@ from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from idom.backend.types import Location
 from idom.config import IDOM_WEB_MODULES_DIR
-from idom.core.hooks import Context, create_context, use_context
+from idom.core.hooks import ContextType, create_context, use_context
 from idom.core.layout import Layout, LayoutEvent
 from idom.core.serve import (
     RecvCoroutine,
@@ -30,9 +30,7 @@ from .utils import CLIENT_BUILD_DIR, safe_client_build_dir_path
 
 logger = logging.getLogger(__name__)
 
-WebSocketContext: type[Context[WebSocket | None]] = create_context(
-    None, "WebSocketContext"
-)
+WebSocketContext: ContextType[WebSocket | None] = create_context(None, "WebSocket")
 
 
 def configure(

--- a/src/idom/backend/tornado.py
+++ b/src/idom/backend/tornado.py
@@ -18,7 +18,7 @@ from tornado.wsgi import WSGIContainer
 
 from idom.backend.types import Location
 from idom.config import IDOM_WEB_MODULES_DIR
-from idom.core.hooks import Context, create_context, use_context
+from idom.core.hooks import ContextType, create_context, use_context
 from idom.core.layout import Layout, LayoutEvent
 from idom.core.serve import VdomJsonPatch, serve_json_patch
 from idom.core.types import ComponentConstructor
@@ -26,9 +26,7 @@ from idom.core.types import ComponentConstructor
 from .utils import CLIENT_BUILD_DIR, safe_client_build_dir_path
 
 
-ConnectionContext: type[Context[Connection | None]] = create_context(
-    None, "ConnectionContext"
-)
+ConnectionContext: ContextType[Connection | None] = create_context(None, "Connection")
 
 
 def configure(

--- a/src/idom/core/_thread_local.py
+++ b/src/idom/core/_thread_local.py
@@ -1,5 +1,5 @@
 from threading import Thread, current_thread
-from typing import Callable, Generic, TypeVar
+from typing import Any, Callable, Generic, TypeVar, cast
 from weakref import WeakKeyDictionary
 
 
@@ -9,7 +9,7 @@ _StateType = TypeVar("_StateType")
 class ThreadLocal(Generic[_StateType]):
     """Utility for managing per-thread state information"""
 
-    def __init__(self, default: Callable[[], _StateType]):
+    def __init__(self, default: Callable[[], _StateType] = cast(Any, lambda: None)):
         self._default = default
         self._state: WeakKeyDictionary[Thread, _StateType] = WeakKeyDictionary()
 

--- a/src/idom/types.py
+++ b/src/idom/types.py
@@ -5,7 +5,7 @@
 """
 
 from .backend.types import BackendImplementation, Location
-from .core.hooks import Context
+from .core.hooks import ContextType
 from .core.types import (
     ComponentConstructor,
     ComponentType,
@@ -29,7 +29,7 @@ from .core.types import (
 __all__ = [
     "ComponentConstructor",
     "ComponentType",
-    "Context",
+    "ContextType",
     "EventHandlerDict",
     "EventHandlerFunc",
     "EventHandlerMapping",

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -935,11 +935,9 @@ async def test_use_context_default_value():
 
 
 def test_context_repr():
-    Context = idom.create_context(None)
-    assert re.match(r"Context\(.*\)", repr(Context()))
-
-    MyContext = idom.create_context(None, name="MyContext")
-    assert re.match(r"MyContext\(.*\)", repr(MyContext()))
+    Context = idom.create_context(None, "MyContext")
+    assert repr(Context) == "ContextType('MyContext')"
+    assert repr(Context()) == "ContextProvider('MyContext')"
 
 
 async def test_use_context_only_renders_for_value_change():


### PR DESCRIPTION
# Description

The current implementation has `create_context` return a new `Context` class. This makes extending `Context` more complicated since you need to create a new subclass in addition to the one you might return from a `create_my_context` function in a similar way to how `create_context` works now. For example:

```python
from idom.core.hooks import Context

class MyContext(Context):
    custom_attribute = "something"

def create_my_context(custom_attribute):
    class _MyContext(Context):
        custom_attribute = custom_attribute
    _MyContext.__name__ = "MyContext"
    return MyContext
```

This is just overly complicated. This rework makes the following, much simpler extension, possible:

```python
from idom.core.hooks import ContextType

class MyContextType:
    def __init__(self, custom_attribute):
        super().__init__()

def create_my_context(custom_attribute):
    return MyContextType(custom_attribute)
```

# Checklist:

Please update this checklist as you complete each item:

- [ ] Tests have been included for all bug fixes or added functionality.
- [ ] The `changelog.rst` has been updated with any significant changes.
- [ ] GitHub Issues which may be closed by this Pull Request have been linked.
- [x] I have left irrelevant checklist items unchecked instead of removing them.
