### PR TITLE
add asgiref dep + set default timeout on page

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -23,7 +23,13 @@ more info, see the :ref:`Contributor Guide <Creating a Changelog Entry>`.
 Unreleased
 ----------
 
-No changes.
+**Added**
+
+- :pull:`123` - ``asgiref`` as a dependency
+
+**Changed**
+
+- :pull:`123` - set default timeout on playwright page for testing
 
 
 v0.39.0

--- a/requirements/pkg-deps.txt
+++ b/requirements/pkg-deps.txt
@@ -5,3 +5,4 @@ jsonpatch >=1.32
 fastjsonschema >=2.14.5
 requests >=2
 colorlog >=6
+asgiref >=3

--- a/src/idom/config.py
+++ b/src/idom/config.py
@@ -80,7 +80,8 @@ https://github.com/idom-team/idom/issues/351
 
 IDOM_TESTING_DEFAULT_TIMEOUT = _Option(
     "IDOM_TESTING_DEFAULT_TIMEOUT",
-    3.0,
+    5.0,
     mutable=False,
     validator=float,
 )
+"""A default timeout for testing utilities in IDOM"""

--- a/src/idom/testing/display.py
+++ b/src/idom/testing/display.py
@@ -58,7 +58,7 @@ class DisplayFixture:
                 browser = self._browser
             self.page = await browser.new_page()
 
-        self.page.set_default_timeout(IDOM_TESTING_DEFAULT_TIMEOUT * 1000)
+        self.page.set_default_timeout(IDOM_TESTING_DEFAULT_TIMEOUT.current * 1000)
 
         if not hasattr(self, "backend"):
             self.backend = BackendFixture()

--- a/src/idom/testing/display.py
+++ b/src/idom/testing/display.py
@@ -7,6 +7,7 @@ from typing import Any
 from playwright.async_api import Browser, BrowserContext, Page, async_playwright
 
 from idom import html
+from idom.config import IDOM_TESTING_DEFAULT_TIMEOUT
 from idom.types import RootComponentConstructor
 
 from .backend import BackendFixture
@@ -56,6 +57,8 @@ class DisplayFixture:
             else:
                 browser = self._browser
             self.page = await browser.new_page()
+
+        self.page.set_default_timeout(IDOM_TESTING_DEFAULT_TIMEOUT * 1000)
 
         if not hasattr(self, "backend"):
             self.backend = BackendFixture()


### PR DESCRIPTION
# Description

- Add `asgiref` as a dependency (must have been included by another package before now).
- Set default timeout on playwright page for testing - we have a IDOM_TESTING_DEFAULT_TIMEOUT, but it's not applied there.

# Checklist:

Please update this checklist as you complete each item:

- [ ] Tests have been included for all bug fixes or added functionality.
- [x] The `changelog.rst` has been updated with any significant changes.
- [ ] GitHub Issues which may be closed by this Pull Request have been linked.
- [x] I have left irrelevant checklist items unchecked instead of removing them.
