### PR TITLE
Track contexts in hooks as state

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -23,13 +23,18 @@ more info, see the :ref:`Contributor Guide <Creating a Changelog Entry>`.
 Unreleased
 ----------
 
-**Added**
+**Fixed**
 
-- :pull:`123` - ``asgiref`` as a dependency
+- :issue:`789` - Conditionally rendered components cannot use contexts
 
 **Changed**
 
 - :pull:`123` - set default timeout on playwright page for testing
+- :pull:`787` - Track contexts in hooks as state
+
+**Added**
+
+- :pull:`123` - ``asgiref`` as a dependency
 
 
 v0.39.0

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -31,6 +31,7 @@ Unreleased
 
 - :pull:`123` - set default timeout on playwright page for testing
 - :pull:`787` - Track contexts in hooks as state
+- :pull:`787` - remove non-standard ``name`` argument from ``create_context``
 
 **Added**
 

--- a/src/idom/__init__.py
+++ b/src/idom/__init__.py
@@ -4,7 +4,6 @@ from .core import hooks
 from .core.component import component
 from .core.events import event
 from .core.hooks import (
-    Context,
     create_context,
     use_callback,
     use_context,
@@ -28,7 +27,6 @@ __version__ = "0.39.0"  # DO NOT MODIFY
 __all__ = [
     "component",
     "config",
-    "Context",
     "create_context",
     "event",
     "hooks",

--- a/src/idom/__init__.py
+++ b/src/idom/__init__.py
@@ -4,6 +4,7 @@ from .core import hooks
 from .core.component import component
 from .core.events import event
 from .core.hooks import (
+    Context,
     create_context,
     use_callback,
     use_context,
@@ -27,6 +28,7 @@ __version__ = "0.39.0"  # DO NOT MODIFY
 __all__ = [
     "component",
     "config",
+    "Context",
     "create_context",
     "event",
     "hooks",

--- a/src/idom/backend/flask.py
+++ b/src/idom/backend/flask.py
@@ -37,7 +37,7 @@ from .utils import safe_client_build_dir_path, safe_web_modules_dir_path
 
 logger = logging.getLogger(__name__)
 
-ConnectionContext: type[Context[Connection | None]] = create_context(
+ConnectionContext: Context[Connection | None] = create_context(
     None, "ConnectionContext"
 )
 

--- a/src/idom/backend/flask.py
+++ b/src/idom/backend/flask.py
@@ -37,9 +37,7 @@ from .utils import safe_client_build_dir_path, safe_web_modules_dir_path
 
 logger = logging.getLogger(__name__)
 
-ConnectionContext: Context[Connection | None] = create_context(
-    None, "ConnectionContext"
-)
+ConnectionContext: Context[Connection | None] = create_context(None)
 
 
 def configure(

--- a/src/idom/backend/sanic.py
+++ b/src/idom/backend/sanic.py
@@ -32,7 +32,7 @@ from .utils import safe_client_build_dir_path, safe_web_modules_dir_path
 
 logger = logging.getLogger(__name__)
 
-ConnectionContext: type[Context[Connection | None]] = create_context(
+ConnectionContext: Context[Connection | None] = create_context(
     None, "ConnectionContext"
 )
 

--- a/src/idom/backend/sanic.py
+++ b/src/idom/backend/sanic.py
@@ -32,9 +32,7 @@ from .utils import safe_client_build_dir_path, safe_web_modules_dir_path
 
 logger = logging.getLogger(__name__)
 
-ConnectionContext: Context[Connection | None] = create_context(
-    None, "ConnectionContext"
-)
+ConnectionContext: Context[Connection | None] = create_context(None)
 
 
 def configure(

--- a/src/idom/backend/starlette.py
+++ b/src/idom/backend/starlette.py
@@ -30,7 +30,7 @@ from .utils import CLIENT_BUILD_DIR, safe_client_build_dir_path
 
 logger = logging.getLogger(__name__)
 
-WebSocketContext: Context[WebSocket | None] = create_context(None, "WebSocketContext")
+WebSocketContext: Context[WebSocket | None] = create_context(None)
 
 
 def configure(

--- a/src/idom/backend/starlette.py
+++ b/src/idom/backend/starlette.py
@@ -30,9 +30,7 @@ from .utils import CLIENT_BUILD_DIR, safe_client_build_dir_path
 
 logger = logging.getLogger(__name__)
 
-WebSocketContext: type[Context[WebSocket | None]] = create_context(
-    None, "WebSocketContext"
-)
+WebSocketContext: Context[WebSocket | None] = create_context(None, "WebSocketContext")
 
 
 def configure(

--- a/src/idom/backend/tornado.py
+++ b/src/idom/backend/tornado.py
@@ -26,7 +26,7 @@ from idom.core.types import ComponentConstructor
 from .utils import CLIENT_BUILD_DIR, safe_client_build_dir_path
 
 
-ConnectionContext: type[Context[Connection | None]] = create_context(
+ConnectionContext: Context[Connection | None] = create_context(
     None, "ConnectionContext"
 )
 

--- a/src/idom/backend/tornado.py
+++ b/src/idom/backend/tornado.py
@@ -26,9 +26,7 @@ from idom.core.types import ComponentConstructor
 from .utils import CLIENT_BUILD_DIR, safe_client_build_dir_path
 
 
-ConnectionContext: Context[Connection | None] = create_context(
-    None, "ConnectionContext"
-)
+ConnectionContext: Context[Connection | None] = create_context(None)
 
 
 def configure(

--- a/src/idom/backend/tornado.py
+++ b/src/idom/backend/tornado.py
@@ -10,6 +10,7 @@ from urllib.parse import urljoin
 
 from tornado.httpserver import HTTPServer
 from tornado.httputil import HTTPServerRequest
+from tornado.ioloop import IOLoop
 from tornado.log import enable_pretty_logging
 from tornado.platform.asyncio import AsyncIOMainLoop
 from tornado.web import Application, RequestHandler, StaticFileHandler
@@ -67,8 +68,7 @@ async def serve_development_app(
 ) -> None:
     enable_pretty_logging()
 
-    # setup up tornado to use asyncio
-    AsyncIOMainLoop().install()
+    AsyncIOMainLoop.current().install()
 
     server = HTTPServer(app)
     server.listen(port, host)

--- a/src/idom/backend/tornado.py
+++ b/src/idom/backend/tornado.py
@@ -10,7 +10,6 @@ from urllib.parse import urljoin
 
 from tornado.httpserver import HTTPServer
 from tornado.httputil import HTTPServerRequest
-from tornado.ioloop import IOLoop
 from tornado.log import enable_pretty_logging
 from tornado.platform.asyncio import AsyncIOMainLoop
 from tornado.web import Application, RequestHandler, StaticFileHandler

--- a/src/idom/core/_f_back.py
+++ b/src/idom/core/_f_back.py
@@ -7,7 +7,7 @@ from types import FrameType
 def f_module_name(index: int = 0) -> str:
     frame = f_back(index + 1)
     if frame is None:
-        return ""
+        return ""  # pragma: no cover
     name = frame.f_globals.get("__name__", "")
     assert isinstance(name, str), "Expected module name to be a string"
     return name
@@ -20,4 +20,4 @@ def f_back(index: int = 0) -> FrameType | None:
             return frame
         frame = frame.f_back
         index -= 1
-    return None
+    return None  # pragma: no cover

--- a/src/idom/core/_f_back.py
+++ b/src/idom/core/_f_back.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import inspect
+from types import FrameType
+
+
+def f_module_name(index: int = 0) -> str:
+    frame = f_back(index + 1)
+    if frame is None:
+        return ""
+    name = frame.f_globals.get("__name__", "")
+    assert isinstance(name, str), "Expected module name to be a string"
+    return name
+
+
+def f_back(index: int = 0) -> FrameType | None:
+    frame = inspect.currentframe()
+    while frame is not None:
+        if index < 0:
+            return frame
+        frame = frame.f_back
+        index -= 1
+    return None

--- a/src/idom/core/_thread_local.py
+++ b/src/idom/core/_thread_local.py
@@ -20,6 +20,3 @@ class ThreadLocal(Generic[_StateType]):
         else:
             state = self._state[thread]
         return state
-
-    def set(self, state: _StateType) -> None:
-        self._state[current_thread()] = state

--- a/src/idom/core/hooks.py
+++ b/src/idom/core/hooks.py
@@ -27,7 +27,6 @@ from typing_extensions import Protocol
 from idom.config import IDOM_DEBUG_MODE
 from idom.utils import Ref
 
-from ._f_back import f_module_name
 from ._thread_local import ThreadLocal
 from .types import ComponentType, Key, VdomDict
 from .vdom import vdom

--- a/src/idom/core/hooks.py
+++ b/src/idom/core/hooks.py
@@ -8,7 +8,6 @@ from typing import (
     Any,
     Awaitable,
     Callable,
-    ClassVar,
     Dict,
     Generic,
     List,
@@ -21,12 +20,14 @@ from typing import (
     cast,
     overload,
 )
+from warnings import warn
 
 from typing_extensions import Protocol
 
 from idom.config import IDOM_DEBUG_MODE
 from idom.utils import Ref
 
+from ._f_back import f_module_name
 from ._thread_local import ThreadLocal
 from .types import ComponentType, Key, VdomDict
 from .vdom import vdom
@@ -240,107 +241,94 @@ def use_debug_value(
 
 
 def create_context(
-    default_value: _StateType, name: str | None = None
-) -> type[Context[_StateType]]:
+    default_value: _StateType, name: str = "Context"
+) -> Context[_StateType]:
     """Return a new context type for use in :func:`use_context`"""
-
-    class _Context(Context[_StateType]):
-        _default_value = default_value
-
-    _Context.__name__ = name or "Context"
-
-    return _Context
-
-
-def use_context(context_type: type[Context[_StateType]]) -> _StateType:
-    """Get the current value for the given context type.
-
-    See the full :ref:`Use Context` docs for more information.
-    """
-    # We have to use a Ref here since, if initially context_type._current is None, and
-    # then on a subsequent render it is present, we need to be able to dynamically adopt
-    # that newly present current context. When we update it though, we don't need to
-    # schedule a new render since we're already rending right now. Thus we can't do this
-    # with use_state() since we'd incur an extra render when calling set_state.
-    context_ref: Ref[Context[_StateType] | None] = use_ref(None)
-
-    if context_ref.current is None:
-        provided_context = context_type._current.get()
-        if provided_context is None:
-            # Cast required because of: https://github.com/python/mypy/issues/5144
-            return cast(_StateType, context_type._default_value)
-        context_ref.current = provided_context
-
-    # We need the hook now so that we can schedule an update when
-    hook = current_hook()
-
-    context = context_ref.current
-
-    @use_effect
-    def subscribe_to_context_change() -> Callable[[], None]:
-        def set_context(new: Context[_StateType]) -> None:
-            # We don't need to check if `new is not context_ref.current` because we only
-            # trigger this callback when the value of a context, and thus the context
-            # itself changes. Therefore we can always schedule a render.
-            context_ref.current = new
-            hook.schedule_render()
-
-        context.subscribers.add(set_context)
-        return lambda: context.subscribers.remove(set_context)
-
-    return context.value
+    warn(
+        "The 'create_context' function is deprecated. "
+        "Use the 'Context' class instead. "
+        "This function will be removed in a future release."
+    )
+    return Context(name, default_value)
 
 
-_UNDEFINED: Any = object()
+_UNDEFINED = object()
 
 
 class Context(Generic[_StateType]):
+    """Returns a :class:`ContextProvider` component"""
 
-    # This should be _StateType instead of Any, but it can't due to this limitation:
-    # https://github.com/python/mypy/issues/5144
-    _default_value: ClassVar[Any]
+    def __init__(self, name: str, default_value: _StateType) -> None:
+        self.name = name
+        self.default_value = default_value
 
-    _current: ClassVar[ThreadLocal[Context[Any] | None]]
-
-    def __init_subclass__(cls) -> None:
-        # every context type tracks which of its instances are currently in use
-        cls._current = ThreadLocal(lambda: None)
-
-    def __init__(
+    def __call__(
         self,
         *children: Any,
         value: _StateType = _UNDEFINED,
         key: Key | None = None,
+    ) -> (
+        # users don't need to see that this is a ContextProvider
+        ComponentType
+    ):
+        return ContextProvider(
+            *children,
+            value=self.default_value if value is _UNDEFINED else value,
+            key=key,
+            type=self,
+        )
+
+    def __repr__(self):
+        return f"{type(self).__name__}({self.name!r})"
+
+
+def use_context(context: Context[_StateType]) -> _StateType:
+    """Get the current value for the given context type.
+
+    See the full :ref:`Use Context` docs for more information.
+    """
+    hook = current_hook()
+
+    provider = hook.get_context_provider(context)
+    if provider is None:
+        return context.default_value
+
+    @use_effect
+    def subscribe_to_context_change() -> Callable[[], None]:
+        provider.subscribers.add(hook)
+        return lambda: provider.subscribers.remove(hook)
+
+    return provider.value
+
+
+class ContextProvider(Generic[_StateType]):
+    def __init__(
+        self,
+        *children: Any,
+        value: _StateType,
+        key: Key | None,
+        type: Context[_StateType],
     ) -> None:
         self.children = children
-        self.value: _StateType = self._default_value if value is _UNDEFINED else value
+        self.value = value
         self.key = key
-        self.subscribers: set[Callable[[Context[_StateType]], None]] = set()
-        self.type = self.__class__
+        self.subscribers: set[LifeCycleHook] = set()
+        self.type = type
 
     def render(self) -> VdomDict:
-        current_ctx = self.__class__._current
-
-        prior_ctx = current_ctx.get()
-        current_ctx.set(self)
-
-        def reset_ctx() -> None:
-            current_ctx.set(prior_ctx)
-
-        current_hook().add_effect(COMPONENT_DID_RENDER_EFFECT, reset_ctx)
-
+        current_hook().set_context_provider(self)
         return vdom("", *self.children)
 
-    def should_render(self, new: Context[_StateType]) -> bool:
+    def should_render(self, new: ContextProvider[_StateType]) -> bool:
         if self.value is not new.value:
-            new.subscribers.update(self.subscribers)
-            for set_context in self.subscribers:
-                set_context(new)
+            for hook in self.subscribers:
+                hook.set_context_provider(new)
+                hook.schedule_render()
             return True
         return False
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}({id(self)})"
+        return f"{type(self).__name__}({self.type.name!r})"
 
 
 _ActionType = TypeVar("_ActionType")
@@ -558,14 +546,14 @@ def _try_to_infer_closure_values(
 
 def current_hook() -> LifeCycleHook:
     """Get the current :class:`LifeCycleHook`"""
-    hook = _current_hook.get()
-    if hook is None:
+    hook_stack = _hook_stack.get()
+    if not hook_stack:
         msg = "No life cycle hook is active. Are you rendering in a layout?"
         raise RuntimeError(msg)
-    return hook
+    return hook_stack[-1]
 
 
-_current_hook: ThreadLocal[LifeCycleHook | None] = ThreadLocal(lambda: None)
+_hook_stack: ThreadLocal[list[LifeCycleHook]] = ThreadLocal(list)
 
 
 EffectType = NewType("EffectType", str)
@@ -630,9 +618,8 @@ class LifeCycleHook:
 
             hook.affect_component_did_render()
 
-            # This should only be called after any child components yielded by
-            # component_instance.render() have also been rendered because effects of
-            # this type must run after the full set of changes have been resolved.
+            # This should only be called after the full set of changes associated with a
+            # given render have been completed.
             hook.affect_layout_did_render()
 
             # Typically an event occurs and a new render is scheduled, thus begining
@@ -650,6 +637,7 @@ class LifeCycleHook:
 
     __slots__ = (
         "__weakref__",
+        "_context_providers",
         "_current_state_index",
         "_event_effects",
         "_is_rendering",
@@ -666,6 +654,7 @@ class LifeCycleHook:
         self,
         schedule_render: Callable[[], None],
     ) -> None:
+        self._context_providers: dict[Context[Any], ContextProvider[Any]] = {}
         self._schedule_render_callback = schedule_render
         self._schedule_render_later = False
         self._is_rendering = False
@@ -699,6 +688,14 @@ class LifeCycleHook:
     def add_effect(self, effect_type: EffectType, function: Callable[[], None]) -> None:
         """Trigger a function on the occurance of the given effect type"""
         self._event_effects[effect_type].append(function)
+
+    def set_context_provider(self, provider: ContextProvider[Any]) -> None:
+        self._context_providers[provider.type] = provider
+
+    def get_context_provider(
+        self, context: Context[_StateType]
+    ) -> ContextProvider[_StateType] | None:
+        return self._context_providers.get(context)
 
     def affect_component_will_render(self, component: ComponentType) -> None:
         """The component is about to render"""
@@ -753,13 +750,16 @@ class LifeCycleHook:
         This method is called by a layout before entering the render method
         of this hook's associated component.
         """
-        _current_hook.set(self)
+        hook_stack = _hook_stack.get()
+        if hook_stack:
+            parent = hook_stack[-1]
+            self._context_providers.update(parent._context_providers)
+        hook_stack.append(self)
 
     def unset_current(self) -> None:
         """Unset this hook as the active hook in this thread"""
         # this assertion should never fail - primarilly useful for debug
-        assert _current_hook.get() is self
-        _current_hook.set(None)
+        assert _hook_stack.get().pop() is self
 
     def _schedule_render(self) -> None:
         try:

--- a/src/idom/core/hooks.py
+++ b/src/idom/core/hooks.py
@@ -323,7 +323,7 @@ class ContextProvider(Generic[_StateType]):
         return False
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}({self.type!r})"
+        return f"{type(self).__name__}({self.type})"
 
 
 _ActionType = TypeVar("_ActionType")

--- a/src/idom/core/layout.py
+++ b/src/idom/core/layout.py
@@ -481,12 +481,6 @@ def _check_should_render(old: ComponentType, new: ComponentType) -> bool:
         return False
 
 
-def _iter_model_state_children(model_state: _ModelState) -> Iterator[_ModelState]:
-    yield model_state
-    for child in model_state.children_by_key.values():
-        yield from _iter_model_state_children(child)
-
-
 def _new_root_model_state(
     component: ComponentType, schedule_render: Callable[[_LifeCycleStateId], None]
 ) -> _ModelState:

--- a/src/idom/core/vdom.py
+++ b/src/idom/core/vdom.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 import logging
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, cast
 

--- a/src/idom/core/vdom.py
+++ b/src/idom/core/vdom.py
@@ -23,6 +23,8 @@ from idom.core.types import (
     VdomJson,
 )
 
+from ._f_back import f_module_name
+
 
 logger = logging.getLogger()
 
@@ -223,13 +225,10 @@ def make_vdom_constructor(
         "element represented by a :class:`VdomDict`."
     )
 
-    frame = inspect.currentframe()
-    if frame is not None and frame.f_back is not None and frame.f_back is not None:
-        module = frame.f_back.f_globals.get("__name__")  # module in outer frame
-        if module is not None:
-            qualname = module + "." + tag
-            constructor.__module__ = module
-            constructor.__qualname__ = qualname
+    module_name = f_module_name(1)
+    if module_name:
+        constructor.__module__ = module_name
+        constructor.__qualname__ = f"{module_name}.{tag}"
 
     return constructor
 

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -934,9 +934,8 @@ async def test_use_context_default_value():
 
 
 def test_context_repr():
-    sample_context = idom.Context("sample_context", None)
-    assert repr(sample_context) == "Context('sample_context')"
-    assert repr(sample_context()) == "ContextProvider('sample_context')"
+    sample_context = idom.create_context(None)
+    assert repr(sample_context()) == f"ContextProvider({sample_context})"
 
 
 async def test_use_context_only_renders_for_value_change():
@@ -1065,8 +1064,8 @@ async def test_nested_contexts_do_not_conflict():
 
 
 async def test_neighboring_contexts_do_not_conflict():
-    LeftContext = idom.create_context(None, name="Left")
-    RightContext = idom.create_context(None, name="Right")
+    LeftContext = idom.create_context(None)
+    RightContext = idom.create_context(None)
 
     set_left = idom.Ref()
     set_right = idom.Ref()
@@ -1249,7 +1248,7 @@ async def test_use_debug_mode_does_not_log_if_not_in_debug_mode():
 async def test_conditionally_rendered_components_can_use_context():
     set_state = idom.Ref()
     used_context_values = []
-    some_context = idom.create_context("some_context", None)
+    some_context = idom.create_context(None)
 
     @idom.component
     def SomeComponent():

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -1,5 +1,4 @@
 import asyncio
-import re
 
 import pytest
 

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -1262,15 +1262,15 @@ async def test_conditionally_rendered_components_can_use_context():
 
     @idom.component
     def FirstCondition():
-        used_context_values.append(idom.use_context(some_context))
+        used_context_values.append(idom.use_context(some_context) + "-1")
 
     @idom.component
     def SecondCondition():
-        used_context_values.append(idom.use_context(some_context))
+        used_context_values.append(idom.use_context(some_context) + "-2")
 
     async with idom.Layout(some_context(SomeComponent(), value="the-value")) as layout:
         await layout.render()
-        assert used_context_values == ["the-value"]
+        assert used_context_values == ["the-value-1"]
         set_state.current(False)
         await layout.render()
-        assert used_context_values == ["the-value", "the-value"]
+        assert used_context_values == ["the-value-1", "the-value-2"]

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -1249,7 +1249,7 @@ async def test_use_debug_mode_does_not_log_if_not_in_debug_mode():
 async def test_conditionally_rendered_components_can_use_context():
     set_state = idom.Ref()
     used_context_values = []
-    some_context = idom.Context("some_context", None)
+    some_context = idom.create_context("some_context", None)
 
     @idom.component
     def SomeComponent():

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -935,11 +935,9 @@ async def test_use_context_default_value():
 
 
 def test_context_repr():
-    Context = idom.create_context(None)
-    assert re.match(r"Context\(.*\)", repr(Context()))
-
-    MyContext = idom.create_context(None, name="MyContext")
-    assert re.match(r"MyContext\(.*\)", repr(MyContext()))
+    sample_context = idom.Context("sample_context", None)
+    assert repr(sample_context) == "Context('sample_context')"
+    assert repr(sample_context()) == "ContextProvider('sample_context')"
 
 
 async def test_use_context_only_renders_for_value_change():

--- a/tests/test_core/test_layout.py
+++ b/tests/test_core/test_layout.py
@@ -1027,7 +1027,7 @@ async def test_element_keys_inside_components_do_not_reset_state_of_component():
     reset in any `Child()` components but there was a bug where that happened.
     """
 
-    effect_calls_without_state = []
+    effect_calls_without_state = set()
     set_child_key_num = StaticEventHandler()
     did_call_effect = asyncio.Event()
 
@@ -1051,7 +1051,7 @@ async def test_element_keys_inside_components_do_not_reset_state_of_component():
         async def record_if_state_is_reset():
             if state:
                 return
-            effect_calls_without_state.append(child_key)
+            effect_calls_without_state.add(child_key)
             set_state(1)
             did_call_effect.set()
 
@@ -1063,13 +1063,13 @@ async def test_element_keys_inside_components_do_not_reset_state_of_component():
     async with idom.Layout(Parent()) as layout:
         await layout.render()
         await did_call_effect.wait()
-        assert effect_calls_without_state == ["some-key", "key-0"]
+        assert effect_calls_without_state == {"some-key", "key-0"}
         did_call_effect.clear()
 
         for i in range(1, 5):
             await layout.deliver(LayoutEvent(set_child_key_num.target, []))
             await layout.render()
-            assert effect_calls_without_state == ["some-key", "key-0"]
+            assert effect_calls_without_state == {"some-key", "key-0"}
             did_call_effect.clear()
 
 


### PR DESCRIPTION
# Description

closes: #789 

components which are newly added to the layout after the initial render do not have access to contexts. we solve this by tracking life cycle hooks in stack and copying the context providers from parent to child hooks.

# Checklist:

Please update this checklist as you complete each item:

- [x] Tests have been included for all bug fixes or added functionality.
- [x] The `changelog.rst` has been updated with any significant changes.
- [x] GitHub Issues which may be closed by this Pull Request have been linked.
