### PR TITLE
Use LXML for html_to_vdom

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -25,6 +25,7 @@ Unreleased
 
 **Fixed**
 
+- :issue:`777` - Fix edge cases where ``html_to_vdom`` can fail to convert HTML
 - :issue:`789` - Conditionally rendered components cannot use contexts
 - :issue:`773` - Use strict equality check for text, numeric, and binary types in hooks
 - :issue:`801` - Accidental mutation of old model causes invalid JSON Patch
@@ -38,6 +39,7 @@ Unreleased
 **Added**
 
 - :pull:`123` - ``asgiref`` as a dependency
+- :pull:`795` - ``lxml`` as a dependency
 
 
 v0.39.0

--- a/requirements/pkg-deps.txt
+++ b/requirements/pkg-deps.txt
@@ -6,3 +6,4 @@ fastjsonschema >=2.14.5
 requests >=2
 colorlog >=6
 asgiref >=3
+lxml >= 4

--- a/src/idom/backend/utils.py
+++ b/src/idom/backend/utils.py
@@ -35,7 +35,7 @@ def run(
     implementation: BackendImplementation[Any] | None = None,
 ) -> None:
     """Run a component with a development server"""
-    logger.warn(
+    logger.warning(
         "You are running a development server. "
         "Change this before deploying in production!"
     )

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -112,7 +112,7 @@ class _HtmlToVdom:
             vdom["tagName"] = ""
 
         # Get rid of empty VDOM fields
-        self._remove_unneeded_vdom(vdom)
+        self._prune_vdom_fields(vdom)
 
         return vdom
 
@@ -140,7 +140,7 @@ class _HtmlToVdom:
                 vdom["key"] = vdom["children"][0]
 
     @staticmethod
-    def _remove_unneeded_vdom(vdom: Dict):
+    def _prune_vdom_fields(vdom: Dict):
         """Removed unneeded fields from VDOM dict."""
         if not len(vdom["children"]):
             del vdom["children"]

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -119,18 +119,17 @@ def _etree_to_vdom(node: etree._Element, transforms: Iterable[_ModelTransform]) 
     # Convert the lxml node to a VDOM dict
     attributes = dict(node.items())
     key = attributes.pop("key", None)
-    vdom = (
-        # If available, use a constructor from idom.html to create the VDOM dict
-        getattr(idom.html, node.tag)(attributes, *children, key=key)
-        if hasattr(idom.html, node.tag)
-        # Fall back to using a generic VDOM dict
-        else {
-            "tagName": node.tag,
-            "children": children,
-            "attributes": attributes,
-            "key": key,
-        }
-    )
+
+    if hasattr(idom.html, node.tag):
+        vdom = getattr(idom.html, node.tag)(attributes, *children, key=key)
+    else:
+        vdom: VdomDict = {"tagName": node.tag}
+        if children:
+            vdom["children"] = children
+        if attributes:
+            vdom["attributes"] = attributes
+        if key is not None:
+            vdom["key"] = key
 
     # Perform any necessary mutations on the VDOM attributes to meet VDOM spec
     _mutate_vdom(vdom)

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -67,9 +67,10 @@ def html_to_vdom(html: str, *transforms: _ModelTransform):
         raise TypeError(f"Encountered unsupported type {type(html)} from {html}")
 
     # If the user provided a string, convert it to a list of lxml.etree nodes
-    nodes: List = fragments_fromstring(
-        html, no_leading_text=True, parser=etree.HTMLParser()
+    parser = etree.HTMLParser(
+        remove_comments=True, remove_pis=True, remove_blank_text=True
     )
+    nodes: List = fragments_fromstring(html, no_leading_text=True, parser=parser)
     has_root_node = len(nodes) == 1
 
     # Find or create a root node

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -53,7 +53,7 @@ class Ref(Generic[_RefValue]):
         return f"{type(self).__name__}({current})"
 
 
-def html_to_vdom(html: str, *transforms: _ModelTransform):
+def html_to_vdom(html: str, *transforms: _ModelTransform, recover: bool = False) -> Dict:
     """Transform HTML into a DOM model
     Parameters:
         source:
@@ -62,13 +62,19 @@ def html_to_vdom(html: str, *transforms: _ModelTransform):
             Functions of the form ``transform(old) -> new`` where ``old`` is a VDOM
             dictionary which will be replaced by ``new``. For example, you could use a
             transform function to add highlighting to a ``<code/>`` block.
+        recover:
+            If ``True``, try to repair broken HTML. This may result in parsing invalid
+            HTML as plain text.
     """
     if not isinstance(html, str):
         raise TypeError(f"Encountered unsupported type {type(html)} from {html}")
 
     # If the user provided a string, convert it to a list of lxml.etree nodes
     parser = etree.HTMLParser(
-        remove_comments=True, remove_pis=True, remove_blank_text=True
+        remove_comments=True,
+        remove_pis=True,
+        remove_blank_text=True,
+        recover=recover,
     )
     nodes: List = fragments_fromstring(html, no_leading_text=True, parser=parser)
     has_root_node = len(nodes) == 1

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -5,6 +5,7 @@ from lxml import etree
 from lxml.html import fragments_fromstring
 
 import idom
+from idom.core.vdom import VdomDict
 
 
 _RefValue = TypeVar("_RefValue")
@@ -55,7 +56,7 @@ class Ref(Generic[_RefValue]):
         return f"{type(self).__name__}({current})"
 
 
-def html_to_vdom(html: str, *transforms: _ModelTransform) -> Dict:
+def html_to_vdom(html: str, *transforms: _ModelTransform) -> VdomDict:
     """Transform HTML into a DOM model. Unique keys can be provided to HTML elements
     using a ``key=...`` attribute within your HTML tag.
 
@@ -99,7 +100,9 @@ def html_to_vdom(html: str, *transforms: _ModelTransform) -> Dict:
     return vdom
 
 
-def _etree_to_vdom(node: etree._Element, transforms: Iterable[_ModelTransform]) -> Dict:
+def _etree_to_vdom(
+    node: etree._Element, transforms: Iterable[_ModelTransform]
+) -> VdomDict:
     """Recusively transform an lxml etree node into a DOM model
 
     Parameters:
@@ -141,7 +144,7 @@ def _etree_to_vdom(node: etree._Element, transforms: Iterable[_ModelTransform]) 
     return vdom
 
 
-def _mutate_vdom(vdom: Dict):
+def _mutate_vdom(vdom: VdomDict):
     """Performs any necessary mutations on the VDOM attributes to meet VDOM spec.
 
     Currently, this function only transforms the ``style`` attribute into a dictionary whose keys are
@@ -168,7 +171,7 @@ def _mutate_vdom(vdom: Dict):
 
 def _generate_vdom_children(
     node: etree._Element, transforms: Iterable[_ModelTransform]
-) -> List[Union[Dict, str]]:
+) -> List[Union[VdomDict, str]]:
     """Generates a list of VDOM children from an lxml node.
 
     Inserts inner text and/or tail text inbetween VDOM children, if necessary.

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -53,7 +53,7 @@ class Ref(Generic[_RefValue]):
         return f"{type(self).__name__}({current})"
 
 
-def html_to_vdom(html: str, *transforms: _ModelTransform, recover: bool = False) -> Dict:
+def html_to_vdom(html: str, *transforms: _ModelTransform) -> Dict:
     """Transform HTML into a DOM model
     Parameters:
         source:
@@ -62,9 +62,6 @@ def html_to_vdom(html: str, *transforms: _ModelTransform, recover: bool = False)
             Functions of the form ``transform(old) -> new`` where ``old`` is a VDOM
             dictionary which will be replaced by ``new``. For example, you could use a
             transform function to add highlighting to a ``<code/>`` block.
-        recover:
-            If ``True``, try to repair broken HTML. This may result in parsing invalid
-            HTML as plain text.
     """
     if not isinstance(html, str):
         raise TypeError(f"Encountered unsupported type {type(html)} from {html}")
@@ -74,7 +71,7 @@ def html_to_vdom(html: str, *transforms: _ModelTransform, recover: bool = False)
         remove_comments=True,
         remove_pis=True,
         remove_blank_text=True,
-        recover=recover,
+        recover=False,
     )
     nodes: List = fragments_fromstring(html, no_leading_text=True, parser=parser)
     has_root_node = len(nodes) == 1
@@ -97,7 +94,7 @@ def html_to_vdom(html: str, *transforms: _ModelTransform, recover: bool = False)
     return vdom
 
 
-def _etree_to_vdom(node: etree._Element, *transforms: _ModelTransform):
+def _etree_to_vdom(node: etree._Element, *transforms: _ModelTransform) -> Dict:
     """Recusively transform an lxml etree node into a DOM model
     Parameters:
         source:

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -64,16 +64,14 @@ def html_to_vdom(html: Union[str, etree._Element], *transforms: _ModelTransform)
             transform function to add highlighting to a ``<code/>`` block.
     """
 
-    # Keep track of whether this is the root node
-    root_node = False
-
     # If the user provided a string, convert it to an lxml.etree node.
     if isinstance(html, str):
         parser = etree.HTMLParser()
         node = fragment_fromstring(html, create_parent=True, parser=parser)
-        root_node = True
+        root_node = True  # Only the root node is a HTML string
     elif isinstance(html, etree._Element):
         node = html
+        root_node = False
     else:
         raise TypeError(
             f"HtmlToVdom encountered unsupported type {type(html)} from {html}"

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -82,14 +82,14 @@ def html_to_vdom(html: Union[str, etree._Element], *transforms: _ModelTransform)
     # Convert the lxml node to a VDOM dict.
     vdom = {
         "tagName": node.tag,
-        "children": _generate_child_vdom(node, transforms),
+        "children": _generate_vdom_children(node, transforms),
         "attributes": dict(node.items()),
         "eventHandlers": {},
         "importSource": {},
         "key": "",
         "error": "",
     }
-    _vdom_mutations(vdom)
+    _mutate_vdom(vdom)
 
     # Apply any provided transforms.
     for transform in transforms:
@@ -105,7 +105,7 @@ def html_to_vdom(html: Union[str, etree._Element], *transforms: _ModelTransform)
     return vdom
 
 
-def _vdom_mutations(vdom: Dict):
+def _mutate_vdom(vdom: Dict):
     """Performs any necessary mutations on the VDOM attributes to meet VDOM spec
     and/or to make elements properly renderable in React."""
     # Convert style attributes to VDOM spec
@@ -144,9 +144,9 @@ def _prune_vdom_fields(vdom: Dict):
         del vdom["error"]
 
 
-def _generate_child_vdom(
+def _generate_vdom_children(
     node: etree._Element, transforms: Iterable[_ModelTransform]
-) -> List:
+) -> List[Union[Dict, str]]:
     """Recursively generate a list of VDOM children from an lxml node."""
     # Insert text inbetween VDOM children, if necessary
     children = [node.text] + list(

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -67,7 +67,7 @@ def html_to_vdom(html: str, *transforms: _ModelTransform) -> Dict:
             dictionary which will be replaced by ``new``. For example, you could use a
             transform function to add highlighting to a ``<code/>`` block.
     """
-    if not isinstance(html, str):
+    if not isinstance(html, str):  # pragma: no cover
         raise TypeError(f"Encountered unsupported type {type(html)} from {html}")
 
     # If the user provided a string, convert it to a list of lxml.etree nodes
@@ -109,7 +109,7 @@ def _etree_to_vdom(node: etree._Element, transforms: Iterable[_ModelTransform]) 
             dictionary which will be replaced by ``new``. For example, you could use a
             transform function to add highlighting to a ``<code/>`` block.
     """
-    if not isinstance(node, etree._Element):
+    if not isinstance(node, etree._Element):  # pragma: no cover
         raise TypeError(f"Encountered unsupported type {type(node)} from {node}")
 
     # This will recursively call _etree_to_vdom() on all children

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -9,7 +9,7 @@ from idom.core.vdom import VdomDict
 
 
 _RefValue = TypeVar("_RefValue")
-_ModelTransform = Callable[[Dict[str, Any]], Any]
+_ModelTransform = Callable[[VdomDict], Any]
 _UNDEFINED: Any = object()
 
 

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -88,7 +88,7 @@ def html_to_vdom(html: str, *transforms: _ModelTransform, recover: bool = False)
             root_node.append(child)
 
     # Convert the lxml node to a VDOM dict
-    vdom = etree_to_vdom(root_node, *transforms)
+    vdom = _etree_to_vdom(root_node, *transforms)
 
     # Change the artificially created root node to a React Fragment, instead of a div
     if not has_root_node:
@@ -97,7 +97,7 @@ def html_to_vdom(html: str, *transforms: _ModelTransform, recover: bool = False)
     return vdom
 
 
-def etree_to_vdom(node: etree._Element, *transforms: _ModelTransform):
+def _etree_to_vdom(node: etree._Element, *transforms: _ModelTransform):
     """Recusively transform an lxml etree node into a DOM model
     Parameters:
         source:
@@ -179,7 +179,7 @@ def _generate_vdom_children(
     return ([node.text] if node.text else []) + list(
         chain(
             *(
-                [etree_to_vdom(child, *transforms)]
+                [_etree_to_vdom(child, *transforms)]
                 + ([child.tail] if child.tail else [])
                 for child in node.iterchildren(None)
             )

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -69,7 +69,7 @@ def html_to_vdom(html: str, *transforms: _ModelTransform) -> VdomDict:
             transform function to add highlighting to a ``<code/>`` block.
     """
     if not isinstance(html, str):  # pragma: no cover
-        raise TypeError(f"Encountered unsupported type {type(html)} from {html}")
+        raise TypeError(f"Expected html to be a string, not {type(html).__name__}")
 
     # If the user provided a string, convert it to a list of lxml.etree nodes
     parser = etree.HTMLParser(
@@ -114,7 +114,7 @@ def _etree_to_vdom(
             transform function to add highlighting to a ``<code/>`` block.
     """
     if not isinstance(node, etree._Element):  # pragma: no cover
-        raise TypeError(f"Encountered unsupported type {type(node)} from {node}")
+        raise TypeError(f"Expected node to be a etree._Element, not {type(node).__name__}")
 
     # This will recursively call _etree_to_vdom() on all children
     children = _generate_vdom_children(node, transforms)

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -113,7 +113,7 @@ def _mutate_vdom(vdom: Dict):
         vdom["attributes"]["style"] = {
             _hypen_to_camel_case(key.strip()): value.strip()
             for key, value in (
-                part.strip().split(":", 1)
+                part.split(":", 1)
                 for part in vdom["attributes"]["style"].split(";")
                 if ":" in part
             )

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -121,7 +121,7 @@ class _HtmlToVdom:
         """Performs any necessary mutations on the VDOM attributes to meet VDOM spec
         and/or to make elements properly renderable in React."""
         # Convert style attributes to VDOM spec
-        if "attributes" in vdom and "style" in vdom["attributes"]:
+        if "style" in vdom["attributes"]:
             style = vdom["attributes"]["style"]
             if isinstance(style, str):
                 style_dict = {}

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -96,6 +96,7 @@ def html_to_vdom(html: str, *transforms: _ModelTransform) -> Dict:
 
 def _etree_to_vdom(node: etree._Element, *transforms: _ModelTransform) -> Dict:
     """Recusively transform an lxml etree node into a DOM model
+    
     Parameters:
         source:
             The ``lxml.etree._Element`` node

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -53,7 +53,7 @@ class Ref(Generic[_RefValue]):
         return f"{type(self).__name__}({current})"
 
 
-def html_to_vdom(html: Union[str, etree._Element], *transforms: _ModelTransform):
+def html_to_vdom(html: str, *transforms: _ModelTransform):
     """Transform HTML into a DOM model
     Parameters:
         source:
@@ -64,6 +64,10 @@ def html_to_vdom(html: Union[str, etree._Element], *transforms: _ModelTransform)
             transform function to add highlighting to a ``<code/>`` block.
     """
 
+    return _html_to_vdom(html, *transforms)
+
+def _html_to_vdom(html: Union[str, etree._Element], *transforms: _ModelTransform):
+    """A recursive function to convert HTML to a VDOM model"""
     # If the user provided a string, convert it to an lxml.etree node.
     if isinstance(html, str):
         parser = etree.HTMLParser()
@@ -150,7 +154,7 @@ def _generate_vdom_children(
     return ([node.text] if node.text else []) + list(
         chain(
             *(
-                [html_to_vdom(child, *transforms)]
+                [_html_to_vdom(child, *transforms)]
                 + ([child.tail] if child.tail else [])
                 for child in node.iterchildren(None)
             )

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -89,7 +89,7 @@ def html_to_vdom(html: str, *transforms: _ModelTransform, strict: bool = True) -
         raise HTMLParseError(
             "An error has occurred while parsing the HTML.\n\n"
             "This HTML may be malformatted, or may not perfectly adhere to HTML5.\n"
-            "If you believe the exception above was intentional, "
+            "If you believe the exception above was due to something intentional, "
             "you can disable the strict parameter on html_to_vdom().\n"
             "Otherwise, repair your broken HTML and try again."
         ) from e

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -75,7 +75,7 @@ class _HtmlToVdom:
         self.transforms = transforms
 
     def convert(self, html: Union[str, etree._Element]):
-        """Convert an lxml.etree node tree into a VDOM dict."""
+        """Convert html string -> lxml node tree -> VDOM dict."""
         # Keep track of whether this is the root node
         root_node = False
 
@@ -141,7 +141,7 @@ class _HtmlToVdom:
 
     @staticmethod
     def _prune_vdom_fields(vdom: Dict):
-        """Removed unneeded fields from VDOM dict."""
+        """Remove unneeded fields from VDOM dict."""
         if not len(vdom["children"]):
             del vdom["children"]
         if not len(vdom["attributes"]):

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -109,15 +109,15 @@ def _mutate_vdom(vdom: Dict):
     """Performs any necessary mutations on the VDOM attributes to meet VDOM spec
     and/or to make elements properly renderable in React."""
     # Convert style attributes to VDOM spec
-    if "style" in vdom["attributes"]:
-        style = vdom["attributes"]["style"]
-        if isinstance(style, str):
-            style_dict = {}
-            for k, v in (part.split(":", 1) for part in style.split(";") if part):
-                title_case_key = k.title().replace("-", "")
-                camel_case_key = title_case_key[:1].lower() + title_case_key[1:]
-                style_dict[camel_case_key] = v
-            vdom["attributes"]["style"] = style_dict
+    if "style" in vdom["attributes"] and isinstance(vdom["attributes"]["style"], str):
+        vdom["attributes"]["style"] = {
+            _hypen_to_camel_case(key.strip()): value.strip()
+            for key, value in (
+                part.strip().split(":", 1)
+                for part in vdom["attributes"]["style"].split(";")
+                if ":" in part
+            )
+        }
 
     # Set key attribute for scripts to prevent re-execution during re-renders
     if vdom["tagName"] == "script":
@@ -158,3 +158,11 @@ def _generate_vdom_children(
             )
         )
     )
+
+
+def _hypen_to_camel_case(css_key: str) -> str:
+    """Convert a hypenated string to camelCase."""
+    first_word, *subsequent_words = css_key.split("-")
+
+    # Use map() to titlecase all subsequent words
+    return "".join([first_word.lower(), *map(str.title, subsequent_words)])

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -147,16 +147,14 @@ def _prune_vdom_fields(vdom: Dict):
 def _generate_vdom_children(
     node: etree._Element, transforms: Iterable[_ModelTransform]
 ) -> List[Union[Dict, str]]:
-    """Recursively generate a list of VDOM children from an lxml node."""
-    # Insert text inbetween VDOM children, if necessary
-    children = [node.text] + list(
+    """Recursively generate a list of VDOM children from an lxml node.
+    Inserts inner text and/or tail text inbetween VDOM children, if necessary."""
+    return ([node.text] if node.text else []) + list(
         chain(
             *(
-                [html_to_vdom(child, *transforms), child.tail]
+                [html_to_vdom(child, *transforms)]
+                + ([child.tail] if child.tail else [])
                 for child in node.iterchildren(None)
             )
         )
     )
-
-    # Remove None from the list of children from empty text/tail values
-    return list(filter(None, children))

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -201,15 +201,7 @@ def _generate_vdom_children(
     )
 
 
-def _hypen_to_camel_case(css_key: str) -> str:
+def _hypen_to_camel_case(string: str) -> str:
     """Convert a hypenated string to camelCase."""
-    first_word, *subsequent_words = css_key.split("-")
-
-    return "".join(
-        [
-            # Lowercase the first word
-            first_word.lower(),
-            # Use map() to titlecase all subsequent words
-            *map(str.title, subsequent_words),
-        ]
-    )
+    first, remainder = string.split("-", 1)
+    return first.lower() + remainder.title().replace("-", "")

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -158,6 +158,9 @@ def _mutate_vdom(vdom: VdomDict):
         and "style" in vdom["attributes"]
         and isinstance(vdom["attributes"]["style"], str)
     ):
+        # Convince type checker that it's safe to mutate attributes
+        assert isinstance(vdom["attributes"], dict)
+
         # Convert style attribute from str -> dict with camelCase keys
         vdom["attributes"]["style"] = {
             _hypen_to_camel_case(key.strip()): value.strip()

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -73,10 +73,7 @@ def html_to_vdom(html: str, *transforms: _ModelTransform) -> VdomDict:
 
     # If the user provided a string, convert it to a list of lxml.etree nodes
     parser = etree.HTMLParser(
-        remove_comments=True,
-        remove_pis=True,
-        remove_blank_text=True,
-        recover=False,
+        remove_comments=True, remove_pis=True, remove_blank_text=True
     )
     nodes: List = fragments_fromstring(html, no_leading_text=True, parser=parser)
     has_root_node = len(nodes) == 1
@@ -114,7 +111,9 @@ def _etree_to_vdom(
             transform function to add highlighting to a ``<code/>`` block.
     """
     if not isinstance(node, etree._Element):  # pragma: no cover
-        raise TypeError(f"Expected node to be a etree._Element, not {type(node).__name__}")
+        raise TypeError(
+            f"Expected node to be a etree._Element, not {type(node).__name__}"
+        )
 
     # This will recursively call _etree_to_vdom() on all children
     children = _generate_vdom_children(node, transforms)

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -89,7 +89,7 @@ def html_to_vdom(html: str, *transforms: _ModelTransform) -> Dict:
             root_node.append(child)
 
     # Convert the lxml node to a VDOM dict
-    vdom = _etree_to_vdom(root_node, *transforms)
+    vdom = _etree_to_vdom(root_node, transforms)
 
     # Change the artificially created root node to a React Fragment, instead of a div
     if not has_root_node:
@@ -98,7 +98,7 @@ def html_to_vdom(html: str, *transforms: _ModelTransform) -> Dict:
     return vdom
 
 
-def _etree_to_vdom(node: etree._Element, *transforms: _ModelTransform) -> Dict:
+def _etree_to_vdom(node: etree._Element, transforms: Iterable[_ModelTransform]) -> Dict:
     """Recusively transform an lxml etree node into a DOM model
 
     Parameters:
@@ -186,7 +186,7 @@ def _generate_vdom_children(
     return ([node.text] if node.text else []) + list(
         chain(
             *(
-                [_etree_to_vdom(child, *transforms)]
+                [_etree_to_vdom(child, transforms)]
                 + ([child.tail] if child.tail else [])
                 for child in node.iterchildren(None)
             )

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -131,8 +131,11 @@ def _etree_to_vdom(node: etree._Element, *transforms: _ModelTransform) -> Dict:
 
 
 def _mutate_vdom(vdom: Dict):
-    """Performs any necessary mutations on the VDOM attributes to meet VDOM spec
-    and/or to make elements properly renderable in React."""
+    """Performs any necessary mutations on the VDOM attributes to meet VDOM spec.
+    
+    It also transforms the ``style`` attribute into a dictionary whose keys are
+    camelCase so as to be renderable by React.
+    """
     # Convert style attributes to VDOM spec
     if "style" in vdom["attributes"] and isinstance(vdom["attributes"]["style"], str):
         vdom["attributes"]["style"] = {

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -172,7 +172,9 @@ def _generate_vdom_children(
     node: etree._Element, transforms: Iterable[_ModelTransform]
 ) -> List[Union[Dict, str]]:
     """Recursively generate a list of VDOM children from an lxml node.
-    Inserts inner text and/or tail text inbetween VDOM children, if necessary."""
+    
+    Inserts inner text and/or tail text inbetween VDOM children, if necessary.
+    """
     return ([node.text] if node.text else []) + list(
         chain(
             *(

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -85,7 +85,7 @@ def html_to_vdom(html: str, *transforms: _ModelTransform, strict: bool = True) -
         nodes: List = fragments_fromstring(html, no_leading_text=True, parser=parser)
     except etree.XMLSyntaxError as e:
         if not strict:
-            raise e
+            raise e  # pragma: no cover
         raise HTMLParseError(
             "An error has occurred while parsing the HTML.\n\n"
             "This HTML may be malformatted, or may not perfectly adhere to HTML5.\n"

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -191,15 +191,7 @@ def _generate_vdom_children(
     )
 
 
-def _hypen_to_camel_case(css_key: str) -> str:
+def _hypen_to_camel_case(string: str) -> str:
     """Convert a hypenated string to camelCase."""
-    first_word, *subsequent_words = css_key.split("-")
-
-    return "".join(
-        [
-            # Lowercase the first word
-            first_word.lower(),
-            # Use map() to titlecase all subsequent words
-            *map(str.title, subsequent_words),
-        ]
-    )
+    first, _, remainder = string.partition("-")
+    return first.lower() + remainder.title().replace("-", "")

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -52,63 +52,81 @@ class Ref(Generic[_RefValue]):
         return f"{type(self).__name__}({current})"
 
 
-def _set_if_val_exists(object, key, value):
-    """Sets a key on a dictionary if the value's length is greater than 0."""
-    if len(value):
-        object[key] = value
+def html_to_vdom(html: str, *transforms: _ModelTransform):
+    """Transform HTML into a DOM model
+    Parameters:
+        source:
+            The raw HTML as a string
+        transforms:
+            Functions of the form ``transform(old) -> new`` where ``old`` is a VDOM
+            dictionary which will be replaced by ``new``. For example, you could use a
+            transform function to add highlighting to a ``<code/>`` block.
+    """
+
+    if not isinstance(html, str):
+        raise TypeError("html_to_vdom expects a string!")
+
+    return HtmlToVdom().convert(html, *transforms)
 
 
-def _vdom_attributes(object):
-    if "attributes" in object and "style" in object["attributes"]:
-        style = object["attributes"]["style"]
-        if isinstance(style, str):
-            style_dict = {}
-            for k, v in (part.split(":", 1) for part in style.split(";") if part):
-                title_case_key = k.title().replace("-", "")
-                camel_case_key = title_case_key[:1].lower() + title_case_key[1:]
-                style_dict[camel_case_key] = v
-            object["attributes"]["style"] = style_dict
+class HtmlToVdom:
+    def convert(self, html: Union[str, etree._Element], *transforms: _ModelTransform):
+        """Convert an lxml.etree node tree into a VDOM dict."""
+        # Keep track of whether this is the root node
+        root_node = False
 
+        # If the user provided a string, convert it to an lxml.etree node.
+        if isinstance(html, str):
+            parser = etree.HTMLParser()
+            node = fragment_fromstring(html, create_parent=True, parser=parser)
+            root_node = True
+        elif isinstance(html, etree._Element):
+            node = html
+        else:
+            raise TypeError("html_to_vdom expects a string or lxml.etree._Element")
 
-def _vdom_key(object):
-    if object["tagName"] == "script":
-        if not isinstance(object["children"][0], str):
-            # The script tag contents should be the first child
-            raise TypeError("Could not find script tag contents!")
-        if object["children"][0]:
-            object["key"] = object["children"][0]
+        # Recursively convert the lxml.etree node to a VDOM dict.
+        vdom = {"tagName": node.tag}
+        node_children = [node.text] if node.text else []
+        node_children.extend([self.convert(child) for child in node.iterchildren(None)])
+        self._set_if_val_exists(vdom, "children", node_children)
+        self._set_if_val_exists(vdom, "attributes", dict(node.items()))
+        self._vdom_attributes(vdom)
+        self._vdom_key(vdom)
 
+        # Apply any provided transforms.
+        for transform in transforms:
+            vdom = transform(vdom)
 
-def html_to_vdom(html: Union[str, etree._Element], *transforms: _ModelTransform):
-    """Convert an lxml.etree node tree into a VDOM dict."""
-    # Keep track of whether this is the root node
-    root_node = False
+        # The root node is always a React Fragment
+        if root_node:
+            vdom["tagName"] = ""
 
-    # If the user provided a string, convert it to an lxml.etree node.
-    if isinstance(html, str):
-        parser = etree.HTMLParser()
-        node = fragment_fromstring(html, create_parent=True, parser=parser)
-        root_node = True
-    elif isinstance(html, etree._Element):
-        node = html
-    else:
-        raise TypeError("html_to_vdom expects a string or lxml.etree._Element")
+        return vdom
 
-    # Convert the lxml.etree node to a VDOM dict.
-    vdom = {"tagName": node.tag}
-    node_children = [node.text] if node.text else []
-    node_children.extend([html_to_vdom(child) for child in node.iterchildren(None)])
-    _set_if_val_exists(vdom, "children", node_children)
-    _set_if_val_exists(vdom, "attributes", dict(node.items()))
-    _vdom_attributes(vdom)
-    _vdom_key(vdom)
+    @staticmethod
+    def _set_if_val_exists(object, key, value):
+        """Sets a key on a dictionary if the value's length is greater than 0."""
+        if len(value):
+            object[key] = value
 
-    # Apply any provided transforms.
-    for transform in transforms:
-        vdom = transform(vdom)
+    @staticmethod
+    def _vdom_attributes(object):
+        if "attributes" in object and "style" in object["attributes"]:
+            style = object["attributes"]["style"]
+            if isinstance(style, str):
+                style_dict = {}
+                for k, v in (part.split(":", 1) for part in style.split(";") if part):
+                    title_case_key = k.title().replace("-", "")
+                    camel_case_key = title_case_key[:1].lower() + title_case_key[1:]
+                    style_dict[camel_case_key] = v
+                object["attributes"]["style"] = style_dict
 
-    # The root node is always a React Fragment
-    if root_node:
-        vdom["tagName"] = ""
-
-    return vdom
+    @staticmethod
+    def _vdom_key(object):
+        if object["tagName"] == "script":
+            if not isinstance(object["children"][0], str):
+                # The script tag contents should be the first child
+                raise TypeError("Could not find script tag contents!")
+            if object["children"][0]:
+                object["key"] = object["children"][0]

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -201,7 +201,15 @@ def _generate_vdom_children(
     )
 
 
-def _hypen_to_camel_case(string: str) -> str:
+def _hypen_to_camel_case(css_key: str) -> str:
     """Convert a hypenated string to camelCase."""
-    first, remainder = string.split("-", 1)
-    return first.lower() + remainder.title().replace("-", "")
+    first_word, *subsequent_words = css_key.split("-")
+
+    return "".join(
+        [
+            # Lowercase the first word
+            first_word.lower(),
+            # Use map() to titlecase all subsequent words
+            *map(str.title, subsequent_words),
+        ]
+    )

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -138,9 +138,6 @@ def _etree_to_vdom(node: etree._Element, transforms: Iterable[_ModelTransform]) 
     for transform in transforms:
         vdom = transform(vdom)
 
-    # Get rid of empty VDOM fields
-    _prune_vdom_fields(vdom)
-
     return vdom
 
 
@@ -167,16 +164,6 @@ def _mutate_vdom(vdom: Dict):
                 if ":" in part
             )
         }
-
-
-def _prune_vdom_fields(vdom: Dict):
-    """Remove unneeded fields from VDOM dict."""
-    if "children" in vdom and not len(vdom["children"]):
-        del vdom["children"]
-    if "attributes" in vdom and not len(vdom["attributes"]):
-        del vdom["attributes"]
-    if "key" in vdom and not vdom["key"]:
-        del vdom["key"]
 
 
 def _generate_vdom_children(

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -56,7 +56,7 @@ class Ref(Generic[_RefValue]):
         return f"{type(self).__name__}({current})"
 
 
-def html_to_vdom(html: str, *transforms: _ModelTransform, strict=True) -> VdomDict:
+def html_to_vdom(html: str, *transforms: _ModelTransform, strict: bool = True) -> VdomDict:
     """Transform HTML into a DOM model. Unique keys can be provided to HTML elements
     using a ``key=...`` attribute within your HTML tag.
 

--- a/src/idom/utils.py
+++ b/src/idom/utils.py
@@ -1,5 +1,5 @@
 from itertools import chain
-from typing import Any, Callable, Dict, Generic, List, TypeVar, Union
+from typing import Any, Callable, Dict, Generic, Iterable, List, TypeVar, Union
 
 from lxml import etree
 from lxml.html import fragment_fromstring
@@ -53,7 +53,7 @@ class Ref(Generic[_RefValue]):
         return f"{type(self).__name__}({current})"
 
 
-def html_to_vdom(html: str, *transforms: _ModelTransform):
+def html_to_vdom(html: Union[str, etree._Element], *transforms: _ModelTransform):
     """Transform HTML into a DOM model
     Parameters:
         source:
@@ -64,108 +64,99 @@ def html_to_vdom(html: str, *transforms: _ModelTransform):
             transform function to add highlighting to a ``<code/>`` block.
     """
 
-    if not isinstance(html, str):
-        raise TypeError("html_to_vdom expects a string!")
+    # Keep track of whether this is the root node
+    root_node = False
 
-    return _HtmlToVdom(*transforms).convert(html)
-
-
-class _HtmlToVdom:
-    def __init__(self, *transforms: _ModelTransform) -> None:
-        self.transforms = transforms
-
-    def convert(self, html: Union[str, etree._Element]):
-        """Convert html string -> lxml node tree -> VDOM dict."""
-        # Keep track of whether this is the root node
-        root_node = False
-
-        # If the user provided a string, convert it to an lxml.etree node.
-        if isinstance(html, str):
-            parser = etree.HTMLParser()
-            node = fragment_fromstring(html, create_parent=True, parser=parser)
-            root_node = True
-        elif isinstance(html, etree._Element):
-            node = html
-        else:
-            raise TypeError(
-                f"HtmlToVdom encountered unsupported type {type(html)} from {html}"
-            )
-
-        # Convert the lxml node to a VDOM dict.
-        vdom = {
-            "tagName": node.tag,
-            "children": self._generate_child_vdom(node),
-            "attributes": dict(node.items()),
-            "eventHandlers": {},
-            "importSource": {},
-            "key": "",
-            "error": "",
-        }
-        self._vdom_mutations(vdom)
-
-        # Apply any provided transforms.
-        for transform in self.transforms:
-            vdom = transform(vdom)
-
-        # The root node is rendered as a React Fragment
-        if root_node:
-            vdom["tagName"] = ""
-
-        # Get rid of empty VDOM fields
-        self._prune_vdom_fields(vdom)
-
-        return vdom
-
-    @staticmethod
-    def _vdom_mutations(vdom: Dict):
-        """Performs any necessary mutations on the VDOM attributes to meet VDOM spec
-        and/or to make elements properly renderable in React."""
-        # Convert style attributes to VDOM spec
-        if "style" in vdom["attributes"]:
-            style = vdom["attributes"]["style"]
-            if isinstance(style, str):
-                style_dict = {}
-                for k, v in (part.split(":", 1) for part in style.split(";") if part):
-                    title_case_key = k.title().replace("-", "")
-                    camel_case_key = title_case_key[:1].lower() + title_case_key[1:]
-                    style_dict[camel_case_key] = v
-                vdom["attributes"]["style"] = style_dict
-
-        # Set key attribute for scripts to prevent re-execution during re-renders
-        if vdom["tagName"] == "script":
-            if not isinstance(vdom["children"][0], str):
-                # The script's source should always be the first child
-                raise LookupError("Could not find script's contents!")
-            if vdom["children"][0]:
-                vdom["key"] = vdom["children"][0]
-
-    @staticmethod
-    def _prune_vdom_fields(vdom: Dict):
-        """Remove unneeded fields from VDOM dict."""
-        if not len(vdom["children"]):
-            del vdom["children"]
-        if not len(vdom["attributes"]):
-            del vdom["attributes"]
-        if not len(vdom["eventHandlers"]):
-            del vdom["eventHandlers"]
-        if not len(vdom["importSource"]):
-            del vdom["importSource"]
-        if not vdom["key"]:
-            del vdom["key"]
-        if not vdom["error"]:
-            del vdom["error"]
-
-    def _generate_child_vdom(self, node: etree._Element) -> list:
-        """Recursively generate a list of VDOM children from an lxml node."""
-        # Insert text inbetween VDOM children, if necessary
-        children = [node.text] + list(
-            chain(
-                *(
-                    [self.convert(child), child.tail]
-                    for child in node.iterchildren(None)
-                )
-            )
+    # If the user provided a string, convert it to an lxml.etree node.
+    if isinstance(html, str):
+        parser = etree.HTMLParser()
+        node = fragment_fromstring(html, create_parent=True, parser=parser)
+        root_node = True
+    elif isinstance(html, etree._Element):
+        node = html
+    else:
+        raise TypeError(
+            f"HtmlToVdom encountered unsupported type {type(html)} from {html}"
         )
 
-        # Remove None from the list of children from empty text/tail values
-        return list(filter(None, children))
+    # Convert the lxml node to a VDOM dict.
+    vdom = {
+        "tagName": node.tag,
+        "children": _generate_child_vdom(node, transforms),
+        "attributes": dict(node.items()),
+        "eventHandlers": {},
+        "importSource": {},
+        "key": "",
+        "error": "",
+    }
+    _vdom_mutations(vdom)
+
+    # Apply any provided transforms.
+    for transform in transforms:
+        vdom = transform(vdom)
+
+    # The root node is rendered as a React Fragment
+    if root_node:
+        vdom["tagName"] = ""
+
+    # Get rid of empty VDOM fields
+    _prune_vdom_fields(vdom)
+
+    return vdom
+
+
+def _vdom_mutations(vdom: Dict):
+    """Performs any necessary mutations on the VDOM attributes to meet VDOM spec
+    and/or to make elements properly renderable in React."""
+    # Convert style attributes to VDOM spec
+    if "style" in vdom["attributes"]:
+        style = vdom["attributes"]["style"]
+        if isinstance(style, str):
+            style_dict = {}
+            for k, v in (part.split(":", 1) for part in style.split(";") if part):
+                title_case_key = k.title().replace("-", "")
+                camel_case_key = title_case_key[:1].lower() + title_case_key[1:]
+                style_dict[camel_case_key] = v
+            vdom["attributes"]["style"] = style_dict
+
+    # Set key attribute for scripts to prevent re-execution during re-renders
+    if vdom["tagName"] == "script":
+        if not isinstance(vdom["children"][0], str):
+            # The script's source should always be the first child
+            raise LookupError("Could not find script's contents!")
+        if vdom["children"][0]:
+            vdom["key"] = vdom["children"][0]
+
+
+def _prune_vdom_fields(vdom: Dict):
+    """Remove unneeded fields from VDOM dict."""
+    if not len(vdom["children"]):
+        del vdom["children"]
+    if not len(vdom["attributes"]):
+        del vdom["attributes"]
+    if not len(vdom["eventHandlers"]):
+        del vdom["eventHandlers"]
+    if not len(vdom["importSource"]):
+        del vdom["importSource"]
+    if not vdom["key"]:
+        del vdom["key"]
+    if not vdom["error"]:
+        del vdom["error"]
+
+
+def _generate_child_vdom(
+    node: etree._Element, transforms: Iterable[_ModelTransform]
+) -> List:
+    """Recursively generate a list of VDOM children from an lxml node."""
+    # Insert text inbetween VDOM children, if necessary
+    children = [node.text] + list(
+        chain(
+            *(
+                [html_to_vdom(child, *transforms), child.tail]
+                for child in node.iterchildren(None)
+            )
+        )
+    )
+
+    # Remove None from the list of children from empty text/tail values
+    return list(filter(None, children))

--- a/src/idom/widgets.py
+++ b/src/idom/widgets.py
@@ -80,7 +80,7 @@ def use_linked_inputs(
     value, set_value = idom.hooks.use_state(initial_value)
 
     def sync_inputs(event: Dict[str, Any]) -> None:
-        new_value = event["value"]
+        new_value = event["target"]["value"]
         set_value(new_value)
         if not new_value and ignore_empty:
             return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,10 +60,7 @@ def test_ref_repr():
     ],
 )
 def test_html_to_vdom(case):
-    assert html_to_vdom(case["source"]) == {
-        "tagName": "",
-        "children": [case["model"]],
-    }
+    assert html_to_vdom(case["source"]) == case["model"]
 
 
 def test_html_to_vdom_transform():
@@ -93,10 +90,7 @@ def test_html_to_vdom_transform():
         ],
     }
 
-    assert html_to_vdom(source, make_links_blue) == {
-        "tagName": "",
-        "children": [expected],
-    }
+    assert html_to_vdom(source, make_links_blue) == expected
 
 
 def test_html_to_vdom_with_null_tag():
@@ -111,10 +105,7 @@ def test_html_to_vdom_with_null_tag():
         ],
     }
 
-    assert html_to_vdom(source) == {
-        "tagName": "",
-        "children": [expected],
-    }
+    assert html_to_vdom(source) == expected
 
 
 def test_html_to_vdom_with_style_attr():
@@ -126,7 +117,24 @@ def test_html_to_vdom_with_style_attr():
         "tagName": "p",
     }
 
-    assert html_to_vdom(source) == {
+    assert html_to_vdom(source) == expected
+
+
+def test_html_to_vdom_with_no_parent_node():
+    source = "<p>Hello</p><div>World</div>"
+
+    expected = {
         "tagName": "",
-        "children": [expected],
+        "children": [
+            {
+                "tagName": "p",
+                "children": ["Hello"],
+            },
+            {
+                "tagName": "div",
+                "children": ["World"],
+            },
+        ],
     }
+
+    assert html_to_vdom(source) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,7 +61,7 @@ def test_ref_repr():
 )
 def test_html_to_vdom(case):
     assert html_to_vdom(case["source"]) == {
-        "tagName": "div",
+        "tagName": "",
         "children": [case["model"]],
     }
 
@@ -93,6 +93,6 @@ def test_html_to_vdom_transform():
     }
 
     assert html_to_vdom(source, make_links_blue) == {
-        "tagName": "div",
+        "tagName": "",
         "children": [expected],
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -97,3 +97,21 @@ def test_html_to_vdom_transform():
         "tagName": "",
         "children": [expected],
     }
+
+
+def test_html_to_vdom_with_null_tag():
+    source = "<p>hello<br>world</p>"
+
+    expected = {
+        "tagName": "p",
+        "children": [
+            "hello",
+            {"tagName": "br"},
+            "world",
+        ],
+    }
+
+    assert html_to_vdom(source) == {
+        "tagName": "",
+        "children": [expected],
+    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -122,7 +122,7 @@ def test_html_to_vdom_with_style_attr():
 
     expected = {
         "attributes": {"style": {"backgroundColor": "green", "color": "red"}},
-        "children": ["A red paragraph."],
+        "children": ["Hello World."],
         "tagName": "p",
     }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -115,3 +115,18 @@ def test_html_to_vdom_with_null_tag():
         "tagName": "",
         "children": [expected],
     }
+
+
+def test_html_to_vdom_with_style_attr():
+    source = '<p style="color: red; background-color : green; ">Hello World.</p>'
+
+    expected = {
+        "attributes": {"style": {"backgroundColor": "green", "color": "red"}},
+        "children": ["A red paragraph."],
+        "tagName": "p",
+    }
+
+    assert html_to_vdom(source) == {
+        "tagName": "",
+        "children": [expected],
+    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -126,14 +126,8 @@ def test_html_to_vdom_with_no_parent_node():
     expected = {
         "tagName": "",
         "children": [
-            {
-                "tagName": "p",
-                "children": ["Hello"],
-            },
-            {
-                "tagName": "div",
-                "children": ["World"],
-            },
+            {"tagName": "p", "children": ["Hello"]},
+            {"tagName": "div", "children": ["World"]},
         ],
     }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,7 +67,7 @@ def test_html_to_vdom(case):
 
 
 def test_html_to_vdom_transform():
-    source = "<p>hello <a>world</a> and <a>universe</a></p>"
+    source = "<p>hello <a>world</a> and <a>universe</a>lmao</p>"
 
     def make_links_blue(node):
         if node["tagName"] == "a":
@@ -89,6 +89,7 @@ def test_html_to_vdom_transform():
                 "children": ["universe"],
                 "attributes": {"style": {"color": "blue"}},
             },
+            "lmao",
         ],
     }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,7 +68,7 @@ def test_html_to_vdom_transform():
 
     def make_links_blue(node):
         if node["tagName"] == "a":
-            node["attributes"]["style"] = {"color": "blue"}
+            node["attributes"] = {"style": {"color": "blue"}}
         return node
 
     expected = {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 import idom
-from idom.utils import html_to_vdom
+from idom.utils import HTMLParseError, html_to_vdom
 
 
 def test_basic_ref_behavior():
@@ -104,7 +104,10 @@ def test_non_html_tag_behavior():
         ],
     }
 
-    assert html_to_vdom(source) == expected
+    assert html_to_vdom(source, strict=False) == expected
+
+    with pytest.raises(HTMLParseError):
+        html_to_vdom(source, strict=True)
 
 
 def test_html_to_vdom_with_null_tag():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,6 +93,20 @@ def test_html_to_vdom_transform():
     assert html_to_vdom(source, make_links_blue) == expected
 
 
+def test_non_html_tag_behavior():
+    source = "<my-tag data-x=something><my-other-tag key=a-key /></my-tag>"
+
+    expected = {
+        "tagName": "my-tag",
+        "attributes": {"data-x": "something"},
+        "children": [
+            {"tagName": "my-other-tag", "key": "a-key"},
+        ],
+    }
+
+    assert html_to_vdom(source) == expected
+
+
 def test_html_to_vdom_with_null_tag():
     source = "<p>hello<br>world</p>"
 


### PR DESCRIPTION
fix #777

Technical Details
- Generate a DOM tree using lxml
- Recursively converts lxml tree to VDOM
- HTML is encapsulated within a React fragment if needed
- Style tags are handled separately
- Utilize `idom.html` constructors for VDOM when possible
- Unneeded VDOM fields are pruned after user transformations are applied
- Uses list comprehension where possible for maximum performance

## Checklist

Please update this checklist as you complete each item:

- [x] Tests have been included for all bug fixes or added functionality.
- [x] The `changelog.rst` has been updated with any significant changes.
- [x] GitHub Issues which may be closed by this Pull Request have been linked.
