### PR TITLE
fix append to stale children ref

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -23,11 +23,13 @@ more info, see the :ref:`Contributor Guide <Creating a Changelog Entry>`.
 Unreleased
 ----------
 
-No changes.
+**Fixed**
+
+- :issue:`806` - child models after a component fail to render
 
 
-v0.40.0
--------
+v0.40.0 (yanked)
+----------------
 :octicon:`milestone` *released on 2022-08-13*
 
 **Fixed**


### PR DESCRIPTION
Closes: #806 

A recent change to how components render saved a new list of children to the parent component. In doing so, this caused references to the old list held in other parts of the layout logic to become stale. The solution is to avoid holding onto a reference to a model's children.

## Checklist

Please update this checklist as you complete each item:

- [x] Tests have been included for all bug fixes or added functionality.
- [x] The `changelog.rst` has been updated with any significant changes.
- [x] GitHub Issues which may be closed by this Pull Request have been linked.
