### PR TITLE
add use_connection hook

### DIFF
--- a/docs/source/_custom_js/package-lock.json
+++ b/docs/source/_custom_js/package-lock.json
@@ -19,7 +19,7 @@
       }
     },
     "../../../src/client/packages/idom-client-react": {
-      "version": "0.39.0",
+      "version": "0.40.2",
       "integrity": "sha512-pIK5eNwFSHKXg7ClpASWFVKyZDYxz59MSFpVaX/OqJFkrJaAxBuhKGXNTMXmuyWOL5Iyvb/ErwwDRxQRzMNkfQ==",
       "license": "MIT",
       "dependencies": {
@@ -27,7 +27,7 @@
         "htm": "^3.0.3"
       },
       "devDependencies": {
-        "jsdom": "16.3.0",
+        "jsdom": "16.5.0",
         "lodash": "^4.17.21",
         "prettier": "^2.5.1",
         "uvu": "^0.5.1"
@@ -604,7 +604,7 @@
       "requires": {
         "fast-json-patch": "^3.0.0-1",
         "htm": "^3.0.3",
-        "jsdom": "16.3.0",
+        "jsdom": "16.5.0",
         "lodash": "^4.17.21",
         "prettier": "^2.5.1",
         "uvu": "^0.5.1"

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -23,7 +23,18 @@ more info, see the :ref:`Contributor Guide <Creating a Changelog Entry>`.
 Unreleased
 ----------
 
-No changes.
+**Changed**
+
+- :pull:`823` - The hooks ``use_location`` and ``use_scope`` are no longer
+  implementation specific and are now available as top-level imports. Instead of each
+  backend defining these hooks, backends establish a ``ConnectionContext`` with this
+  information.
+
+**Added**
+
+- :pull:`823` - There is a new ``use_connection`` hook which returns a ``Connection``
+  object. This ``Connection`` object contains a ``location`` and ``scope``, along with
+  a ``carrier`` which is unique to each backend implementation.
 
 
 v0.40.2

--- a/requirements/pkg-extras.txt
+++ b/requirements/pkg-extras.txt
@@ -1,6 +1,6 @@
 # extra=starlette
 starlette >=0.13.6
-uvicorn[standard] >=0.13.4
+uvicorn[standard] >=0.19.0
 
 # extra=sanic
 sanic >=21
@@ -8,7 +8,7 @@ sanic-cors
 
 # extra=fastapi
 fastapi >=0.63.0
-uvicorn[standard] >=0.13.4
+uvicorn[standard] >=0.19.0
 
 # extra=flask
 flask

--- a/src/idom/__init__.py
+++ b/src/idom/__init__.py
@@ -1,4 +1,5 @@
 from . import backend, config, html, logging, sample, types, web
+from .backend.hooks import use_connection, use_location, use_scope
 from .backend.utils import run
 from .core import hooks
 from .core.component import component
@@ -25,6 +26,7 @@ __author__ = "idom-team"
 __version__ = "0.40.2"  # DO NOT MODIFY
 
 __all__ = [
+    "backend",
     "component",
     "config",
     "create_context",
@@ -38,16 +40,18 @@ __all__ = [
     "Ref",
     "run",
     "sample",
-    "backend",
     "Stop",
     "types",
     "use_callback",
+    "use_connection",
     "use_context",
     "use_debug_value",
     "use_effect",
+    "use_location",
     "use_memo",
     "use_reducer",
     "use_ref",
+    "use_scope",
     "use_state",
     "vdom",
     "web",

--- a/src/idom/backend/_asgi.py
+++ b/src/idom/backend/_asgi.py
@@ -21,7 +21,7 @@ async def serve_development_asgi(
             host=host,
             port=port,
             loop="asyncio",
-            debug=True,
+            reload=True,
         )
     )
 

--- a/src/idom/backend/default.py
+++ b/src/idom/backend/default.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from idom.types import RootComponentConstructor
 
-from .types import BackendImplementation, Location
+from .types import BackendImplementation
 from .utils import all_implementations
 
 
@@ -33,16 +33,6 @@ async def serve_development_app(
     return await _default_implementation().serve_development_app(
         app, host, port, started
     )
-
-
-def use_scope() -> Any:
-    """Return the current ASGI/WSGI scope"""
-    return _default_implementation().use_scope()
-
-
-def use_location() -> Location:
-    """Return the current route as a string"""
-    return _default_implementation().use_location()
 
 
 _DEFAULT_IMPLEMENTATION: BackendImplementation[Any] | None = None

--- a/src/idom/backend/fastapi.py
+++ b/src/idom/backend/fastapi.py
@@ -8,16 +8,10 @@ from . import starlette
 serve_development_app = starlette.serve_development_app
 """Alias for :func:`idom.backend.starlette.serve_development_app`"""
 
-# see: https://github.com/idom-team/flake8-idom-hooks/issues/12
-use_location = starlette.use_location  # noqa: ROH101
+use_connection = starlette.use_connection
 """Alias for :func:`idom.backend.starlette.use_location`"""
 
-# see: https://github.com/idom-team/flake8-idom-hooks/issues/12
-use_scope = starlette.use_scope  # noqa: ROH101
-"""Alias for :func:`idom.backend.starlette.use_scope`"""
-
-# see: https://github.com/idom-team/flake8-idom-hooks/issues/12
-use_websocket = starlette.use_websocket  # noqa: ROH101
+use_websocket = starlette.use_websocket
 """Alias for :func:`idom.backend.starlette.use_websocket`"""
 
 Options = starlette.Options

--- a/src/idom/backend/flask.py
+++ b/src/idom/backend/flask.py
@@ -22,7 +22,6 @@ from flask import (
 from flask_cors import CORS
 from flask_sock import Sock
 from simple_websocket import Server as WebSocket
-from werkzeug.local import LocalProxy
 from werkzeug.serving import BaseWSGIServer, make_server
 
 import idom

--- a/src/idom/backend/flask.py
+++ b/src/idom/backend/flask.py
@@ -112,7 +112,7 @@ def use_websocket() -> WebSocket:
     return use_connection().carrier.websocket
 
 
-def use_request() -> LocalProxy[Request]:
+def use_request() -> Request:
     """Get the current ``Request``"""
     return use_connection().carrier.request
 

--- a/src/idom/backend/hooks.py
+++ b/src/idom/backend/hooks.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any, MutableMapping
+
+from idom.core.hooks import Context, create_context, use_context
+
+from .types import Connection, Location
+
+
+# backend implementations should establish this context at the root of an app
+ConnectionContext: Context[Connection[Any] | None] = create_context(None)
+
+
+def use_connection() -> Connection[Any]:
+    conn = use_context(ConnectionContext)
+    if conn is None:
+        raise RuntimeError("No backend established a connection.")  # pragma: no cover
+    return conn
+
+
+def use_scope() -> MutableMapping[str, Any]:
+    return use_connection().scope
+
+
+def use_location() -> Location:
+    return use_connection().location

--- a/src/idom/backend/sanic.py
+++ b/src/idom/backend/sanic.py
@@ -10,7 +10,6 @@ from uuid import uuid4
 
 from sanic import Blueprint, Sanic, request, response
 from sanic.config import Config
-from sanic.models.asgi import ASGIScope
 from sanic.server.websockets.connection import WebSocketConnection
 from sanic_cors import CORS
 

--- a/src/idom/backend/sanic.py
+++ b/src/idom/backend/sanic.py
@@ -4,18 +4,17 @@ import asyncio
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, MutableMapping, Tuple, Union
 from urllib import parse as urllib_parse
 from uuid import uuid4
 
 from sanic import Blueprint, Sanic, request, response
 from sanic.config import Config
 from sanic.models.asgi import ASGIScope
+from sanic.server.websockets.connection import WebSocketConnection
 from sanic_cors import CORS
-from websockets.legacy.protocol import WebSocketCommonProtocol
 
-from idom.backend.types import Location
-from idom.core.hooks import Context, create_context, use_context
+from idom.backend.types import Connection, Location
 from idom.core.layout import Layout, LayoutEvent
 from idom.core.serve import (
     RecvCoroutine,
@@ -27,12 +26,12 @@ from idom.core.serve import (
 from idom.core.types import RootComponentConstructor
 
 from ._asgi import serve_development_asgi
+from .hooks import ConnectionContext
+from .hooks import use_connection as _use_connection
 from .utils import safe_client_build_dir_path, safe_web_modules_dir_path
 
 
 logger = logging.getLogger(__name__)
-
-ConnectionContext: Context[Connection | None] = create_context(None)
 
 
 def configure(
@@ -65,50 +64,25 @@ async def serve_development_app(
     await serve_development_asgi(app, host, port, started)
 
 
-def use_location() -> Location:
-    """Get the current route as a string"""
-    conn = use_connection()
-    search = conn.request.query_string
-    return Location(pathname="/" + conn.path, search="?" + search if search else "")
-
-
-def use_scope() -> ASGIScope:
-    """Get the current ASGI scope"""
-    app = use_request().app
-    try:
-        asgi_app = app._asgi_app
-    except AttributeError:  # pragma: no cover
-        raise RuntimeError("No scope. Sanic may not be running with an ASGI server")
-    return asgi_app.transport.scope
-
-
 def use_request() -> request.Request:
     """Get the current ``Request``"""
-    return use_connection().request
+    return use_connection().carrier.request
 
 
-def use_connection() -> Connection:
+def use_websocket() -> WebSocketConnection:
+    """Get the current websocket"""
+    return use_connection().carrier.websocket
+
+
+def use_connection() -> Connection[_SanicCarrier]:
     """Get the current :class:`Connection`"""
-    connection = use_context(ConnectionContext)
-    if connection is None:
-        raise RuntimeError(  # pragma: no cover
-            "No connection. Are you running with a Sanic server?"
+    conn = _use_connection()
+    if not isinstance(conn.carrier, _SanicCarrier):
+        raise TypeError(  # pragma: no cover
+            f"Connection has unexpected carrier {conn.carrier}. "
+            "Are you running with a Sanic server?"
         )
-    return connection
-
-
-@dataclass
-class Connection:
-    """A simple wrapper for holding connection information"""
-
-    request: request.Request
-    """The current request object"""
-
-    websocket: WebSocketCommonProtocol
-    """A handle to the current websocket"""
-
-    path: str
-    """The current path being served"""
+    return conn
 
 
 @dataclass
@@ -165,12 +139,36 @@ def _setup_single_view_dispatcher_route(
     blueprint: Blueprint, constructor: RootComponentConstructor
 ) -> None:
     async def model_stream(
-        request: request.Request, socket: WebSocketCommonProtocol, path: str = ""
+        request: request.Request, socket: WebSocketConnection, path: str = ""
     ) -> None:
+        app = request.app
+        try:
+            asgi_app = app._asgi_app
+        except AttributeError:  # pragma: no cover
+            logger.warning("No scope. Sanic may not be running with an ASGI server")
+            scope: MutableMapping[str, Any] = {}
+        else:
+            scope = asgi_app.transport.scope
+
         send, recv = _make_send_recv_callbacks(socket)
-        conn = Connection(request, socket, path)
         await serve_json_patch(
-            Layout(ConnectionContext(constructor(), value=conn)),
+            Layout(
+                ConnectionContext(
+                    constructor(),
+                    value=Connection(
+                        scope=scope,
+                        location=Location(
+                            pathname=f"/{path}",
+                            search=(
+                                f"?{request.query_string}"
+                                if request.query_string
+                                else ""
+                            ),
+                        ),
+                        carrier=_SanicCarrier(request, socket),
+                    ),
+                )
+            ),
             send,
             recv,
         )
@@ -180,7 +178,7 @@ def _setup_single_view_dispatcher_route(
 
 
 def _make_send_recv_callbacks(
-    socket: WebSocketCommonProtocol,
+    socket: WebSocketConnection,
 ) -> Tuple[SendCoroutine, RecvCoroutine]:
     async def sock_send(value: VdomJsonPatch) -> None:
         await socket.send(json.dumps(value))
@@ -192,3 +190,14 @@ def _make_send_recv_callbacks(
         return LayoutEvent(**json.loads(data))
 
     return sock_send, sock_recv
+
+
+@dataclass
+class _SanicCarrier:
+    """A simple wrapper for holding connection information"""
+
+    request: request.Request
+    """The current request object"""
+
+    websocket: WebSocketConnection
+    """A handle to the current websocket"""

--- a/src/idom/backend/types.py
+++ b/src/idom/backend/types.py
@@ -51,7 +51,7 @@ class Connection(Generic[_Carrier]):
     """The current location (URL)"""
 
     carrier: _Carrier
-    """How the connection is mediated. For example, a request or websocket.
+    """How the connection is mediated. For example, a websocket.
 
     This typically depends on the backend implementation.
     """

--- a/src/idom/backend/types.py
+++ b/src/idom/backend/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any, MutableMapping, TypeVar
+from typing import Any, Generic, MutableMapping, TypeVar
 
 from typing_extensions import Protocol, runtime_checkable
 
@@ -36,11 +36,25 @@ class BackendImplementation(Protocol[_App]):
     ) -> None:
         """Run an application using a development server"""
 
-    def use_scope(self) -> MutableMapping[str, Any]:
-        """Get an ASGI scope or WSGI environment dictionary"""
 
-    def use_location(self) -> Location:
-        """Get the current location (URL)"""
+_Carrier = TypeVar("_Carrier")
+
+
+@dataclass
+class Connection(Generic[_Carrier]):
+    """Represents a connection with a client"""
+
+    scope: MutableMapping[str, Any]
+    """An ASGI scope or WSGI environment dictionary"""
+
+    location: Location
+    """The current location (URL)"""
+
+    carrier: _Carrier
+    """How the connection is mediated. For example, a request or websocket.
+
+    This typically depends on the backend implementation.
+    """
 
 
 @dataclass
@@ -55,4 +69,7 @@ class Location:
     """the path of the URL for the location"""
 
     search: str = ""
-    """A search or query string - a '?' followed by the parameters of the URL."""
+    """A search or query string - a '?' followed by the parameters of the URL.
+
+    If there are no search parameters this should be an empty string
+    """

--- a/src/idom/types.py
+++ b/src/idom/types.py
@@ -4,7 +4,8 @@
 - :mod:`idom.backend.types`
 """
 
-from .backend.types import BackendImplementation, Location
+from .backend.types import BackendImplementation, Connection, Location
+from .core.component import Component
 from .core.hooks import Context
 from .core.types import (
     ComponentConstructor,
@@ -27,8 +28,11 @@ from .core.types import (
 
 
 __all__ = [
+    "BackendImplementation",
+    "Component",
     "ComponentConstructor",
     "ComponentType",
+    "Connection",
     "Context",
     "EventHandlerDict",
     "EventHandlerFunc",
@@ -45,5 +49,4 @@ __all__ = [
     "VdomChildren",
     "VdomDict",
     "VdomJson",
-    "BackendImplementation",
 ]

--- a/tests/test_backend/test_common.py
+++ b/tests/test_backend/test_common.py
@@ -1,4 +1,4 @@
-from typing import MutableMapping, get_type_hints
+from typing import MutableMapping
 
 import pytest
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,6 +7,7 @@ from playwright.async_api import Browser
 import idom
 from idom.backend.utils import find_available_port
 from idom.testing import BackendFixture, DisplayFixture
+from tests.tooling.common import DEFAULT_TYPE_DELAY
 
 
 JS_DIR = Path(__file__).parent / "js"
@@ -121,6 +122,6 @@ async def test_slow_server_response_on_input_change(display: DisplayFixture):
     await display.show(SomeComponent)
 
     inp = await display.page.wait_for_selector("#test-input")
-    await inp.type("hello")
+    await inp.type("hello", delay=DEFAULT_TYPE_DELAY)
 
     assert (await inp.evaluate("node => node.value")) == "hello"

--- a/tests/test_core/test_events.py
+++ b/tests/test_core/test_events.py
@@ -8,6 +8,7 @@ from idom.core.events import (
     to_event_handler_function,
 )
 from idom.testing import DisplayFixture, poll
+from tests.tooling.common import DEFAULT_TYPE_DELAY
 
 
 def test_event_handler_repr():
@@ -155,7 +156,7 @@ async def test_can_prevent_event_default_operation(display: DisplayFixture):
     await display.show(Input)
 
     inp = await display.page.wait_for_selector("#input")
-    await inp.type("hello")
+    await inp.type("hello", delay=DEFAULT_TYPE_DELAY)
     # the default action of updating the element's value did not take place
     assert (await inp.evaluate("node => node.value")) == ""
 

--- a/tests/test_core/test_hooks.py
+++ b/tests/test_core/test_hooks.py
@@ -15,6 +15,7 @@ from idom.core.layout import Layout, LayoutUpdate
 from idom.testing import DisplayFixture, HookCatcher, assert_idom_did_log, poll
 from idom.testing.logs import assert_idom_did_not_log
 from idom.utils import Ref
+from tests.tooling.common import DEFAULT_TYPE_DELAY
 
 
 async def test_must_be_rendering_in_layout_to_use_hooks():
@@ -246,7 +247,7 @@ async def test_simple_input_with_use_state(display: DisplayFixture):
     await display.show(Input)
 
     button = await display.page.wait_for_selector("#input")
-    await button.type("this is a test")
+    await button.type("this is a test", delay=DEFAULT_TYPE_DELAY)
     await display.page.wait_for_selector("#complete")
 
     assert message_ref.current == "this is a test"

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import idom
 from idom.testing import DisplayFixture, poll
+from tests.tooling.common import DEFAULT_TYPE_DELAY
 
 
 HERE = Path(__file__).parent
@@ -86,13 +87,13 @@ async def test_use_linked_inputs(display: DisplayFixture):
     input_1 = await display.page.wait_for_selector("#i_1")
     input_2 = await display.page.wait_for_selector("#i_2")
 
-    await input_1.type("hello", delay=50)
+    await input_1.type("hello", delay=DEFAULT_TYPE_DELAY)
 
     assert (await input_1.evaluate("e => e.value")) == "hello"
     assert (await input_2.evaluate("e => e.value")) == "hello"
 
     await input_2.focus()
-    await input_2.type(" world", delay=50)
+    await input_2.type(" world", delay=DEFAULT_TYPE_DELAY)
 
     assert (await input_1.evaluate("e => e.value")) == "hello world"
     assert (await input_2.evaluate("e => e.value")) == "hello world"
@@ -114,14 +115,14 @@ async def test_use_linked_inputs_on_change(display: DisplayFixture):
     input_1 = await display.page.wait_for_selector("#i_1")
     input_2 = await display.page.wait_for_selector("#i_2")
 
-    await input_1.type("hello", delay=20)
+    await input_1.type("hello", delay=DEFAULT_TYPE_DELAY)
 
     poll_value = poll(lambda: value.current)
 
     await poll_value.until_equals("hello")
 
     await input_2.focus()
-    await input_2.type(" world", delay=20)
+    await input_2.type(" world", delay=DEFAULT_TYPE_DELAY)
 
     await poll_value.until_equals("hello world")
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -86,13 +86,13 @@ async def test_use_linked_inputs(display: DisplayFixture):
     input_1 = await display.page.wait_for_selector("#i_1")
     input_2 = await display.page.wait_for_selector("#i_2")
 
-    await input_1.type("hello", delay=20)
+    await input_1.type("hello", delay=50)
 
     assert (await input_1.evaluate("e => e.value")) == "hello"
     assert (await input_2.evaluate("e => e.value")) == "hello"
 
     await input_2.focus()
-    await input_2.type(" world", delay=20)
+    await input_2.type(" world", delay=50)
 
     assert (await input_1.evaluate("e => e.value")) == "hello world"
     assert (await input_2.evaluate("e => e.value")) == "hello world"

--- a/tests/tooling/common.py
+++ b/tests/tooling/common.py
@@ -1,0 +1,2 @@
+# see: https://github.com/microsoft/playwright-python/issues/1614
+DEFAULT_TYPE_DELAY = 100  # miliseconds


### PR DESCRIPTION
closes: #819 

Rather than having a hook registration framework. All we need in order to solve the problem at hand is to make it possible for each respective backend to use a common context through which they can declare a scope and location. To do this we define a `ConnectionContext` that each backend must activate with a `Connection` object. The `Connection` object allows the backend to declare scope, location, and an additional, implementation specific, carrier. The carrier is intended to describe the manner in which a connection is mediated (e.g. an HTTP request or websocket).

As a result of these changes, there are now common hooks for the following:

- `use_connection() -> Connection[Any]`
- `use_scope() -> dict[str, Any]`
- `use_location() -> Location`

Backend implementations provide their own `idom.backend.*.use_connection` hooks, but these return the exact same object as the common `idom.use_connection` hook. The only difference is that the type annotation for the return type is narrowed to reflect the carrier of the backend. In narrowing the type though, various backend implementation are also provide implementation specific `use_request` or `use_websocket` hooks.

## Checklist

Please update this checklist as you complete each item:

- [x] Tests have been included for all bug fixes or added functionality.
- [x] The `changelog.rst` has been updated with any significant changes.
- [x] GitHub Issues which may be closed by this Pull Request have been linked.
