### PR TITLE
use fetch request to upload form data

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -181,6 +181,7 @@ def test_python_suite(session: Session) -> None:
     install_requirements_file(session, "test-env")
     session.run("playwright", "install", "chromium")
     posargs = session.posargs
+    posargs += ["--reruns", "3", "--reruns-delay", "1"]
 
     if "--no-cov" in session.posargs:
         session.log("Coverage won't be checked")

--- a/noxfile.py
+++ b/noxfile.py
@@ -181,7 +181,6 @@ def test_python_suite(session: Session) -> None:
     install_requirements_file(session, "test-env")
     session.run("playwright", "install", "chromium")
     posargs = session.posargs
-    posargs += ["--reruns", "3", "--reruns-delay", "1"]
 
     if "--no-cov" in session.posargs:
         session.log("Coverage won't be checked")

--- a/requirements/pkg-extras.txt
+++ b/requirements/pkg-extras.txt
@@ -3,8 +3,9 @@ starlette >=0.13.6
 uvicorn[standard] >=0.19.0
 
 # extra=sanic
-sanic >=21
+sanic >=21,<22.12
 sanic-cors
+uvicorn[standard] >=0.19.0
 
 # extra=fastapi
 fastapi >=0.63.0

--- a/requirements/test-env.txt
+++ b/requirements/test-env.txt
@@ -9,3 +9,6 @@ playwright
 
 # I'm not quite sure why this needs to be installed for tests with Sanic to pass
 sanic-testing
+
+# required to test uploading form data with starlette
+python-multipart

--- a/src/idom/backend/sanic.py
+++ b/src/idom/backend/sanic.py
@@ -122,8 +122,16 @@ def _setup_common_routes(
     ) -> response.HTTPResponse:
         return response.html(index_html)
 
-    spa_blueprint.add_route(single_page_app_files, "/")
-    spa_blueprint.add_route(single_page_app_files, "/<_:path>")
+    spa_blueprint.add_route(
+        single_page_app_files,
+        "/",
+        name="single_page_app_files_root",
+    )
+    spa_blueprint.add_route(
+        single_page_app_files,
+        "/<_:path>",
+        name="single_page_app_files_path",
+    )
 
     async def asset_files(
         request: request.Request,
@@ -188,8 +196,16 @@ def _setup_single_view_dispatcher_route(
             recv,
         )
 
-    api_blueprint.add_websocket_route(model_stream, f"/{STREAM_PATH.name}")
-    api_blueprint.add_websocket_route(model_stream, f"/{STREAM_PATH.name}/<path:path>/")
+    api_blueprint.add_websocket_route(
+        model_stream,
+        f"/{STREAM_PATH.name}",
+        name="model_stream_root",
+    )
+    api_blueprint.add_websocket_route(
+        model_stream,
+        f"/{STREAM_PATH.name}/<path:path>/",
+        name="model_stream_path",
+    )
 
 
 def _make_send_recv_callbacks(

--- a/src/idom/backend/utils.py
+++ b/src/idom/backend/utils.py
@@ -7,9 +7,8 @@ from contextlib import closing
 from importlib import import_module
 from typing import Any, Iterator
 
+from idom.backend.types import BackendImplementation
 from idom.types import RootComponentConstructor
-
-from .types import BackendImplementation
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
closes: #574 

This change prevents the default behavior of a `<form>` element's `onSubmit` event handler. Instead of navigating away from the current page to submit form data, it is sent to the server via a Javascript `fetch` request. We do not push form data into the URL (this behavior will be left to third party packages like [idom-router](https://github.com/idom-team/idom-router)).

Improving form submission behavior will allow users to use form elements to send, among other things, file data to servers. For example, the following will now be possible:

```python
from idom import component, html
from idom.backend.starlette import configure
from starlette.applications import Starlette

app = Starlette()

async def handle_file_upload(request):
    form = await request.form()
    ...  # do stuff with the form

app.add_route("/file-upload", handle_file_upload, methods=["POST"])

@component
def Example():
    return html.form(
        {
            "enctype": "multipart/form-data",
            "action": "/file-upload",
            "method": "POST",
        },
        html.input({"type": "file", "name": "file", "id": "file-input"}),
        html.input({"type": "submit", "id": "form-submit"}),
    )

configure(app, Example)
```

## Checklist

Please update this checklist as you complete each item:

- [x] Tests have been included for all bug fixes or added functionality.
- [ ] The `changelog.rst` has been updated with any significant changes.
- [ ] GitHub Issues which may be closed by this Pull Request have been linked.
