### PR TITLE
no need to unmount on reconnect

### DIFF
--- a/src/client/packages/idom-client-react/src/mount.js
+++ b/src/client/packages/idom-client-react/src/mount.js
@@ -38,9 +38,6 @@ function mountLayoutWithReconnectingWebSocket(
   socket.onopen = (event) => {
     console.info(`IDOM WebSocket connected.`);
 
-    if (mountState.everMounted) {
-      ReactDOM.unmountComponentAtNode(element);
-    }
     _resetOpenMountState(mountState);
 
     mountLayout(element, {


### PR DESCRIPTION
closes: #760 

I was unable to get preact working with the new React `createRoot` API. We can handle that in a follow-up issue. This narrowly focuses on removing an unnecessary unmount call on reconnect.

## Checklist

Please update this checklist as you complete each item:

- [ ] Tests have been included for all bug fixes or added functionality.
- [ ] The `changelog.rst` has been updated with any significant changes.
- [x] GitHub Issues which may be closed by this Pull Request have been linked.
