### PR TITLE
fix `use_async_effect` cleanup not executed when dependencies change

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -25,7 +25,6 @@ Unreleased
 - :pull:`1308` - Event data now supports accessing properties via dot notation (ex. ``event.target.value``).
 - :pull:`1308` - Added ``reactpy.types.Event`` to provide type hints for the standard ``data`` function argument (for example ``def on_click(event: Event): ...``).
 - :pull:`1113` - Added ``asgi`` and ``jinja`` installation extras (for example ``pip install reactpy[asgi, jinja]``).
-- :pull:`1267` - Added ``shutdown_timeout`` parameter to the ``reactpy.use_async_effect`` hook.
 - :pull:`1113` - Added ``reactpy.executors.asgi.ReactPy`` that can be used to run ReactPy in standalone mode via ASGI.
 - :pull:`1269` - Added ``reactpy.executors.asgi.ReactPyCsr`` that can be used to run ReactPy in standalone mode via ASGI, but rendered entirely client-sided.
 - :pull:`1113` - Added ``reactpy.executors.asgi.ReactPyMiddleware`` that can be used to utilize ReactPy within any ASGI compatible framework.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,11 +210,11 @@ build_client = ['hatch run "src/build_scripts/build_js_client.py" {args}']
 build_app = ['hatch run "src/build_scripts/build_js_app.py" {args}']
 publish_event_to_object = [
   'hatch run javascript:build_event_to_object',
-  'cd "src/js/packages/event-to-object" && bun publish --access public',
+  'cd "src/js/packages/event-to-object" && bunx npm publish --provenance --access public',
 ]
 publish_client = [
   'hatch run javascript:build_client',
-  'cd "src/js/packages/@reactpy/client" && bun publish --access public',
+  'cd "src/js/packages/@reactpy/client" && bunx npm publish --provenance --access public',
 ]
 
 #########################


### PR DESCRIPTION
## Description
- Fix #1327

Fixed a bug where `use_async_effect` cleanup functions were not being executed when dependencies changed.

This required removing `shutdown_timeout` parameter from `use_async_effect`. It is now up to the user to shield against `asyncio.CancelledError` for sensitive operations (such as database queries).

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
